### PR TITLE
ITEM-081: Inline content editing

### DIFF
--- a/src/components/panel/NodeDetailPanel.tsx
+++ b/src/components/panel/NodeDetailPanel.tsx
@@ -13,6 +13,7 @@ import {
   addItem,
   removeItem,
   upsertChecklist,
+  updateBlockText,
 } from "@/lib/content/checklist";
 import { PanelHeader } from "./PanelHeader";
 import { PanelStatus } from "./PanelStatus";
@@ -104,9 +105,14 @@ export function NodeDetailPanel({ node, pinned = false, onClose, readOnly = fals
     }
   }, [node.id, content, persist]);
 
+  const handleBlockUpdate = useCallback(async (blockId: string, newText: string) => {
+    const next = updateBlockText(content, blockId, newText);
+    persist(next);
+  }, [content, persist]);
+
   // Blocks for the non-checklist rich text section (heading, paragraph, note)
   const richBlocks = content.blocks.filter(
-    (b) => b.type === "heading" || b.type === "paragraph" || b.type === "note"
+    (b) => b.type === "heading" || b.type === "paragraph" || b.type === "note" || b.type === "code"
   );
 
   return (
@@ -132,7 +138,10 @@ export function NodeDetailPanel({ node, pinned = false, onClose, readOnly = fals
 
       {richBlocks.length > 0 && (
         <div className="mb-3">
-          <RichTextRenderer blocks={richBlocks} />
+          <RichTextRenderer
+            blocks={richBlocks}
+            onBlockUpdate={!readOnly ? handleBlockUpdate : undefined}
+          />
         </div>
       )}
 

--- a/src/components/panel/RichTextRenderer.tsx
+++ b/src/components/panel/RichTextRenderer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useCallback } from "react";
 import type { ContentBlock, ChecklistItem } from "@/types/node-content";
 
 interface ChecklistHandlers {
@@ -15,6 +15,8 @@ interface RichTextRendererProps {
   blocks: ContentBlock[];
   /** If provided, checklist blocks render as interactive (editable) */
   checklistHandlers?: ChecklistHandlers;
+  /** If provided, text blocks (paragraph/heading/note/code) become click-to-edit */
+  onBlockUpdate?: (blockId: string, newText: string) => void;
 }
 
 function ChecklistRow({
@@ -160,7 +162,98 @@ function ReadOnlyChecklist({
   );
 }
 
-export function RichTextRenderer({ blocks, checklistHandlers }: RichTextRendererProps) {
+// ── Inline-editable text block ────────────────────────────────────────────────
+
+function InlineTextBlock({
+  blockId,
+  initialText,
+  onSave,
+  renderDisplay,
+  multiline = false,
+}: {
+  blockId: string;
+  initialText: string;
+  onSave: (blockId: string, text: string) => void;
+  renderDisplay: (text: string) => React.ReactNode;
+  multiline?: boolean;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(initialText);
+  const inputRef = useRef<HTMLTextAreaElement | HTMLInputElement>(null);
+
+  const startEdit = useCallback(() => {
+    setDraft(initialText);
+    setEditing(true);
+    // Focus after state update
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }, [initialText]);
+
+  const commitEdit = useCallback(() => {
+    setEditing(false);
+    const trimmed = draft.trim();
+    if (trimmed !== initialText) {
+      onSave(blockId, trimmed || initialText);
+    }
+  }, [blockId, draft, initialText, onSave]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      setDraft(initialText);
+      setEditing(false);
+      return;
+    }
+    if (!multiline && e.key === "Enter") {
+      e.preventDefault();
+      commitEdit();
+    }
+    e.stopPropagation();
+  }, [commitEdit, initialText, multiline]);
+
+  if (editing) {
+    const sharedClass =
+      "w-full bg-slate-900/80 border border-violet-700/60 rounded px-2 py-1 text-xs text-slate-200 focus:outline-none focus:border-violet-500 transition-colors resize-none";
+    return multiline ? (
+      <textarea
+        ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+        value={draft}
+        rows={Math.max(2, draft.split("\n").length)}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commitEdit}
+        onKeyDown={handleKeyDown}
+        className={sharedClass}
+        autoFocus
+      />
+    ) : (
+      <input
+        ref={inputRef as React.RefObject<HTMLInputElement>}
+        type="text"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commitEdit}
+        onKeyDown={handleKeyDown}
+        className={sharedClass}
+        autoFocus
+      />
+    );
+  }
+
+  return (
+    <div
+      onClick={startEdit}
+      title="Click to edit"
+      className="cursor-text group relative"
+    >
+      {renderDisplay(initialText)}
+      <span className="absolute -right-1 -top-1 opacity-0 group-hover:opacity-100 transition-opacity text-[9px] text-violet-500 pointer-events-none select-none">
+        ✎
+      </span>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function RichTextRenderer({ blocks, checklistHandlers, onBlockUpdate }: RichTextRendererProps) {
   if (!blocks || blocks.length === 0) return null;
 
   return (
@@ -176,6 +269,20 @@ export function RichTextRenderer({ blocks, checklistHandlers }: RichTextRenderer
                 ? "text-xs font-semibold"
                 : "text-xs font-medium";
             const Tag = `h${level}` as "h1" | "h2" | "h3";
+            if (onBlockUpdate) {
+              return (
+                <InlineTextBlock
+                  key={block.id}
+                  blockId={block.id}
+                  initialText={block.text}
+                  onSave={onBlockUpdate}
+                  multiline={false}
+                  renderDisplay={(text) => (
+                    <Tag className={`${sizeClass} text-slate-200 mt-2 first:mt-0`}>{text}</Tag>
+                  )}
+                />
+              );
+            }
             return (
               <Tag
                 key={block.id}
@@ -187,6 +294,20 @@ export function RichTextRenderer({ blocks, checklistHandlers }: RichTextRenderer
           }
 
           case "paragraph":
+            if (onBlockUpdate) {
+              return (
+                <InlineTextBlock
+                  key={block.id}
+                  blockId={block.id}
+                  initialText={block.text}
+                  onSave={onBlockUpdate}
+                  multiline={true}
+                  renderDisplay={(text) => (
+                    <p className="text-xs text-slate-300 leading-relaxed">{text}</p>
+                  )}
+                />
+              );
+            }
             return (
               <p key={block.id} className="text-xs text-slate-300 leading-relaxed">
                 {block.text}
@@ -201,6 +322,22 @@ export function RichTextRenderer({ blocks, checklistHandlers }: RichTextRenderer
             );
 
           case "note":
+            if (onBlockUpdate) {
+              return (
+                <InlineTextBlock
+                  key={block.id}
+                  blockId={block.id}
+                  initialText={block.text}
+                  onSave={onBlockUpdate}
+                  multiline={true}
+                  renderDisplay={(text) => (
+                    <p className="text-xs text-slate-400 italic leading-relaxed border-l-2 border-slate-700 pl-2">
+                      {text}
+                    </p>
+                  )}
+                />
+              );
+            }
             return (
               <p
                 key={block.id}
@@ -211,6 +348,29 @@ export function RichTextRenderer({ blocks, checklistHandlers }: RichTextRenderer
             );
 
           case "code":
+            if (onBlockUpdate) {
+              return (
+                <InlineTextBlock
+                  key={block.id}
+                  blockId={block.id}
+                  initialText={block.text}
+                  onSave={onBlockUpdate}
+                  multiline={true}
+                  renderDisplay={(text) => (
+                    <div className="rounded bg-slate-950 border border-slate-800 overflow-x-auto">
+                      {block.language && (
+                        <div className="px-3 py-1 border-b border-slate-800 text-[9px] font-mono text-slate-500 uppercase tracking-wider">
+                          {block.language}
+                        </div>
+                      )}
+                      <pre className="px-3 py-2 text-xs text-slate-300 font-mono whitespace-pre-wrap break-all leading-relaxed">
+                        <code>{text}</code>
+                      </pre>
+                    </div>
+                  )}
+                />
+              );
+            }
             return (
               <div key={block.id} className="rounded bg-slate-950 border border-slate-800 overflow-x-auto">
                 {block.language && (

--- a/src/lib/content/checklist.ts
+++ b/src/lib/content/checklist.ts
@@ -84,3 +84,16 @@ export function upsertNote(content: NodeContent, text: string): NodeContent {
 export function removeNote(content: NodeContent): NodeContent {
   return { blocks: content.blocks.filter((b) => b.type !== "note") };
 }
+
+// ── Generic block text update ─────────────────────────────────────────────────
+
+/** Update the `text` field of any block that has one (paragraph, heading, note, code). */
+export function updateBlockText(content: NodeContent, blockId: string, text: string): NodeContent {
+  return {
+    blocks: content.blocks.map((b) => {
+      if (b.id !== blockId) return b;
+      if (b.type === "divider" || b.type === "checklist") return b;
+      return { ...b, text };
+    }),
+  };
+}


### PR DESCRIPTION
## ITEM-081: Inline content editing

### What was built and why

This PR implements click-to-edit inline editing for all text-based content blocks in the `NodeDetailPanel`. Previously, content blocks (paragraph, heading, note, code) were read-only — users could only modify content via the AI chat. Now any text block can be clicked to edit in-place, with changes saved to Supabase on blur.

### Key technical decisions

- **`InlineTextBlock` component** added to `RichTextRenderer.tsx`: a self-contained component that toggles between display mode and an editable input/textarea. Single-line blocks (headings) use `<input>`, multiline blocks (paragraph, note, code) use `<textarea>`. On blur, if the text changed, `onSave(blockId, newText)` is called. Escape key cancels the edit.
- **Visual affordance**: a small `✎` pencil icon appears on hover to signal editability, using Tailwind opacity transitions.
- **`updateBlockText` helper** added to `checklist.ts`: immutably updates the `text` field of any block by ID (skips divider and checklist blocks).
- **`onBlockUpdate` prop** added to `RichTextRenderer`: when provided, all text-capable blocks become editable. When absent (read-only mode), rendering is unchanged — backwards compatible.
- **`handleBlockUpdate` callback** in `NodeDetailPanel`: calls `persist()` which updates local state and writes to Supabase immediately.

### Files changed

- **`src/lib/content/checklist.ts`**: Added `updateBlockText(content, blockId, text)` export.
- **`src/components/panel/RichTextRenderer.tsx`**: Added `InlineTextBlock` component and `onBlockUpdate` prop. Each text block type conditionally wraps in `InlineTextBlock` when `onBlockUpdate` is provided.
- **`src/components/panel/NodeDetailPanel.tsx`**: Imported `updateBlockText`, added `handleBlockUpdate`, passed `onBlockUpdate` to `RichTextRenderer`, updated `richBlocks` filter to include code blocks.

### How to verify

1. Open the app and click any skill node to open its detail panel.
2. If the node has paragraph, heading, note, or code content blocks, hover — a `✎` icon appears.
3. Click the block to edit in-place.
4. Blur to save to Supabase. Reload to confirm persistence.
5. Escape cancels without saving.
6. Read-only mode: blocks remain non-editable.