### PR TITLE
ITEM-127: Enable content editing in pinned ticket detail view

### DIFF
--- a/src/components/panel/InlineTextField.tsx
+++ b/src/components/panel/InlineTextField.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+
+interface InlineTextFieldProps {
+  value: string;
+  placeholder?: string;
+  readOnly?: boolean;
+  onSave?: (newValue: string) => void;
+  className?: string;
+  multiline?: boolean;
+}
+
+/**
+ * A lightweight click-to-edit text field used in NodeDetailPanel.
+ * Shows a pencil hint on hover. Saves on blur or Enter (single-line) / Ctrl+Enter (multiline).
+ */
+export function InlineTextField({
+  value,
+  placeholder = "Click to edit…",
+  readOnly = false,
+  onSave,
+  className = "",
+  multiline = false,
+}: InlineTextFieldProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const inputRef = useRef<HTMLTextAreaElement | HTMLInputElement>(null);
+
+  const startEdit = useCallback(() => {
+    if (readOnly || !onSave) return;
+    setDraft(value);
+    setEditing(true);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }, [readOnly, onSave, value]);
+
+  const commitEdit = useCallback(() => {
+    setEditing(false);
+    const trimmed = draft.trim();
+    if (trimmed !== value) {
+      onSave?.(trimmed);
+    }
+  }, [draft, value, onSave]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setDraft(value);
+        setEditing(false);
+        return;
+      }
+      if (!multiline && e.key === "Enter") {
+        e.preventDefault();
+        commitEdit();
+      }
+      if (multiline && e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        commitEdit();
+      }
+      e.stopPropagation();
+    },
+    [commitEdit, multiline, value]
+  );
+
+  const sharedInputClass =
+    "w-full bg-slate-900/80 border border-violet-700/60 rounded px-2 py-1 text-xs text-slate-300 focus:outline-none focus:border-violet-500 transition-colors resize-none placeholder-slate-600";
+
+  if (editing) {
+    return multiline ? (
+      <textarea
+        ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+        value={draft}
+        rows={Math.max(2, draft.split("\n").length)}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commitEdit}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        className={`${sharedInputClass} mb-3`}
+        autoFocus
+      />
+    ) : (
+      <input
+        ref={inputRef as React.RefObject<HTMLInputElement>}
+        type="text"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commitEdit}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        className={`${sharedInputClass} mb-3`}
+        autoFocus
+      />
+    );
+  }
+
+  // Read-only: don't show if empty
+  if (readOnly && !value) return null;
+
+  return (
+    <div
+      onClick={startEdit}
+      title={!readOnly && onSave ? "Click to edit" : undefined}
+      className={`group relative ${!readOnly && onSave ? "cursor-text" : ""} ${className}`}
+    >
+      {value ? (
+        <span>{value}</span>
+      ) : (
+        <span className="text-slate-600 italic">{placeholder}</span>
+      )}
+      {!readOnly && onSave && (
+        <span className="absolute -right-1 -top-1 opacity-0 group-hover:opacity-100 transition-opacity text-[9px] text-violet-500 pointer-events-none select-none">
+          ✎
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/panel/NodeDetailPanel.tsx
+++ b/src/components/panel/NodeDetailPanel.tsx
@@ -5,6 +5,7 @@ import { motion } from "framer-motion";
 import { createClient } from "@/lib/supabase/client";
 import type { Node3D } from "@/lib/store/tree-store";
 import { useTreeStore } from "@/lib/store/tree-store";
+import { InlineTextField } from "./InlineTextField";
 import type { NodeContent } from "@/types/node-content";
 import {
   parseContent,
@@ -110,6 +111,24 @@ export function NodeDetailPanel({ node, pinned = false, onClose, readOnly = fals
     persist(next);
   }, [content, persist]);
 
+  const handleLabelUpdate = useCallback(async (newLabel: string) => {
+    updateNode(node.id, { label: newLabel });
+    await supabase
+      .from("skill_nodes")
+      .update({ label: newLabel })
+      .eq("id", node.id)
+      .eq("tree_id", node.data.tree_id);
+  }, [node.id, node.data.tree_id, supabase, updateNode]);
+
+  const handleDescriptionUpdate = useCallback(async (newDescription: string) => {
+    updateNode(node.id, { description: newDescription });
+    await supabase
+      .from("skill_nodes")
+      .update({ description: newDescription })
+      .eq("id", node.id)
+      .eq("tree_id", node.data.tree_id);
+  }, [node.id, node.data.tree_id, supabase, updateNode]);
+
   // Blocks for the non-checklist rich text section (heading, paragraph, note)
   const richBlocks = content.blocks.filter(
     (b) => b.type === "heading" || b.type === "paragraph" || b.type === "note" || b.type === "code"
@@ -130,10 +149,18 @@ export function NodeDetailPanel({ node, pinned = false, onClose, readOnly = fals
         label={node.data.label}
         pinned={pinned}
         onClose={onClose}
+        onLabelUpdate={!readOnly ? handleLabelUpdate : undefined}
       />
 
-      {node.data.description && (
-        <p className="text-xs text-slate-400 leading-relaxed mt-1 mb-3">{node.data.description}</p>
+      {(node.data.description || !readOnly) && (
+        <InlineTextField
+          value={node.data.description ?? ""}
+          placeholder="Add a description…"
+          readOnly={readOnly}
+          onSave={!readOnly ? handleDescriptionUpdate : undefined}
+          className="text-xs text-slate-400 leading-relaxed mt-1 mb-3"
+          multiline
+        />
       )}
 
       {richBlocks.length > 0 && (

--- a/src/components/panel/PanelHeader.tsx
+++ b/src/components/panel/PanelHeader.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
 import type { NodeRole } from "@/types/skill-tree";
 
 const roleLabels: Record<NodeRole, string> = {
@@ -11,9 +14,44 @@ interface PanelHeaderProps {
   label: string;
   pinned: boolean;
   onClose?: () => void;
+  /** If provided, the label becomes click-to-edit */
+  onLabelUpdate?: (newLabel: string) => void;
 }
 
-export function PanelHeader({ role, label, pinned, onClose }: PanelHeaderProps) {
+export function PanelHeader({ role, label, pinned, onClose, onLabelUpdate }: PanelHeaderProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(label);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const startEdit = useCallback(() => {
+    if (!onLabelUpdate) return;
+    setDraft(label);
+    setEditing(true);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }, [label, onLabelUpdate]);
+
+  const commitEdit = useCallback(() => {
+    setEditing(false);
+    const trimmed = draft.trim();
+    if (trimmed && trimmed !== label) {
+      onLabelUpdate?.(trimmed);
+    }
+  }, [draft, label, onLabelUpdate]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        commitEdit();
+      } else if (e.key === "Escape") {
+        setDraft(label);
+        setEditing(false);
+      }
+      e.stopPropagation();
+    },
+    [commitEdit, label]
+  );
+
   return (
     <div className="mb-2">
       <div className="flex items-center justify-between">
@@ -38,7 +76,32 @@ export function PanelHeader({ role, label, pinned, onClose }: PanelHeaderProps) 
           </div>
         )}
       </div>
-      <h3 className="font-mono font-bold text-white text-sm mt-0.5">{label}</h3>
+
+      {editing ? (
+        <input
+          ref={inputRef}
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commitEdit}
+          onKeyDown={handleKeyDown}
+          className="w-full bg-slate-900/80 border border-violet-700/60 rounded px-2 py-0.5 font-mono font-bold text-white text-sm mt-0.5 focus:outline-none focus:border-violet-500 transition-colors"
+          autoFocus
+        />
+      ) : (
+        <div
+          onClick={startEdit}
+          title={onLabelUpdate ? "Click to edit" : undefined}
+          className={`group relative mt-0.5 ${onLabelUpdate ? "cursor-text" : ""}`}
+        >
+          <h3 className="font-mono font-bold text-white text-sm">{label}</h3>
+          {onLabelUpdate && (
+            <span className="absolute -right-1 -top-1 opacity-0 group-hover:opacity-100 transition-opacity text-[9px] text-violet-500 pointer-events-none select-none">
+              ✎
+            </span>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What was built and why

This PR adds inline editing capabilities to the `NodeDetailPanel` so that users can edit the node label and description directly from the pinned ticket detail view. Previously, rich content blocks (checklists, paragraphs, notes, headings) were already editable via ITEM-081, but the node label and description fields were rendered as static read-only text with no way to modify them from the panel.

## Key technical decisions

- **New `InlineTextField` component** (`src/components/panel/InlineTextField.tsx`): A reusable click-to-edit field supporting both single-line and multiline modes. Shows a pencil (✎) hint on hover, saves on blur or Enter (Ctrl+Enter for multiline), and cancels with Escape. Empty values show a ghost placeholder only in editable mode.
- **Updated `PanelHeader`** to accept an optional `onLabelUpdate` callback. When provided, the node title (`<h3>`) becomes a click-to-edit inline input. This keeps backward compatibility — read-only views (e.g. `ReadOnlyCanvas`) pass no callback and see no change.
- **`NodeDetailPanel` wiring**: Added `handleLabelUpdate` and `handleDescriptionUpdate` callbacks that call `updateNode` (Zustand store, for instant UI update) and then persist to Supabase. These are passed only when `readOnly` is `false`.
- The description field now renders even when empty in edit mode, showing the ghost placeholder so users know they can add one.

## Files changed

- **`src/components/panel/InlineTextField.tsx`** *(new)*: Reusable inline text/textarea edit component with hover hint, blur-save, and keyboard shortcuts.
- **`src/components/panel/PanelHeader.tsx`**: Added `onLabelUpdate` prop and inline editing state for the node label.
- **`src/components/panel/NodeDetailPanel.tsx`**: Added `handleLabelUpdate` and `handleDescriptionUpdate` handlers; replaced static description `<p>` with `InlineTextField`; wired `onLabelUpdate` to `PanelHeader`.

## How to verify

1. Open the app and navigate to any skill tree view.
2. Click a node to pin it in the detail panel.
3. Click the node title — it should become an editable input. Type a new name and press Enter or click away to save.
4. Click the description area (or the placeholder if empty) — it should become an editable textarea. Edit and blur/Ctrl+Enter to save.
5. Refresh the page to confirm changes persisted to the database.
6. Open a read-only share view and confirm no editing is available there.