### PR TITLE
ITEM-093: Ticket duration from pm_tickets

### DIFF
--- a/src/app/(app)/tree/[id]/page.tsx
+++ b/src/app/(app)/tree/[id]/page.tsx
@@ -81,7 +81,7 @@ export default function TreePage({ params }: { params: Promise<{ id: string }> }
     async function pollNodeStatuses() {
       const { data, error } = await supabase
         .from("skill_nodes")
-        .select("id, status, icon, properties, priority, label, description")
+        .select("id, status, icon, properties, priority, label, description, created_at, completed_at")
         .eq("tree_id", id);
       if (!active || error || !data) return;
       for (const row of data) {

--- a/src/components/canvas/GanttView.tsx
+++ b/src/components/canvas/GanttView.tsx
@@ -13,10 +13,15 @@ import {
   PX_PER_DAY,
 } from "@/lib/gantt/layout";
 
+/**
+ * Bar colours for each ticket status.
+ * Bars span created_at → completed_at (actual ticket duration from pm_tickets).
+ */
 const STATUS_COLORS: Record<string, string> = {
-  completed: "#22d3ee",
-  in_progress: "#f59e0b",
-  locked: "#475569",
+  completed:   "#22d3ee",   // cyan   — ticket finished
+  in_progress: "#f59e0b",   // amber  — actively being worked
+  queued:      "#a78bfa",   // violet — waiting to start
+  locked:      "#475569",   // slate  — not yet reachable
 };
 
 const TYPE_COLORS: Record<string, string> = {
@@ -60,7 +65,6 @@ export function GanttView() {
     const viewableWidth = containerWidth - LABEL_COL_WIDTH;
     const target = Math.max(0, todayOffset - Math.floor(viewableWidth / 2));
     setScrollLeft(target);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [todayOffset]);
 
   const onPointerDown = useCallback((e: React.PointerEvent) => {
@@ -394,7 +398,7 @@ export function GanttView() {
               />
             ))}
 
-            {/* Gantt bars */}
+            {/* Gantt bars — duration from created_at (open) → completed_at (close) */}
             {layout.rows.map((row) => {
               const status = row.node.data.status;
               const type = row.node.data.type ?? row.node.data.role;
@@ -403,12 +407,26 @@ export function GanttView() {
               const isPinned = row.id === pinnedNodeId;
               const isHighlighted = row.id === searchHighlightId;
 
+              // Duration fill: completed tickets show full solid bar (actual duration known).
+              // In-progress: partial fill based on days elapsed vs bar width.
+              // Queued/locked: empty fill — ticket hasn't started.
+              const barDurationDays = row.barWidth / PX_PER_DAY;
+              const elapsedDays =
+                (Date.now() - new Date(row.startLabel).getTime()) /
+                (1000 * 60 * 60 * 24);
+              const fillPercent =
+                status === "completed"
+                  ? 100
+                  : status === "in_progress"
+                  ? Math.min(100, Math.max(10, Math.round((elapsedDays / barDurationDays) * 100)))
+                  : 0;
+
               return (
                 <div
                   key={row.id}
                   data-node="true"
                   onClick={() => setPinnedNode(isPinned ? null : row.id)}
-                  title={`${row.node.data.label}\n${row.startLabel} → ${row.endLabel}`}
+                  title={`${row.node.data.label}\n${row.startLabel} → ${row.endLabel}\nStatus: ${status}`}
                   style={{
                     position: "absolute",
                     top: row.yTop + 8,
@@ -417,13 +435,15 @@ export function GanttView() {
                     height: ROW_HEIGHT - 16,
                     borderRadius: 5,
                     background: isPinned
-                      ? "rgba(99,102,241,0.35)"
-                      : `${barColor}22`,
-                    border: `1.5px solid ${isPinned ? "#818cf8" : borderColor}`,
+                      ? "rgba(99,102,241,0.2)"
+                      : "rgba(255,255,255,0.03)",
+                    border: `1.5px solid ${isPinned ? "#818cf8" : `${barColor}88`}`,
                     boxShadow: isHighlighted
-                      ? "0 0 0 2px #f59e0b"
+                      ? `0 0 0 2px #f59e0b`
                       : isPinned
                       ? "0 0 0 2px rgba(129,140,248,0.5)"
+                      : status === "in_progress"
+                      ? `0 0 8px 1px ${barColor}44`
                       : "none",
                     cursor: "pointer",
                     display: "flex",
@@ -435,18 +455,23 @@ export function GanttView() {
                     transition: "box-shadow 0.15s, border-color 0.15s",
                   }}
                 >
-                  {/* Fill bar based on status */}
+                  {/* Duration fill — solid colour showing actual ticket duration */}
                   <div
                     style={{
                       position: "absolute",
                       left: 0,
                       top: 0,
                       height: "100%",
-                      width: status === "completed" ? "100%" : status === "in_progress" ? "50%" : "0%",
-                      background: `${barColor}33`,
-                      borderRadius: 4,
+                      width: `${fillPercent}%`,
+                      background:
+                        status === "completed"
+                          ? `linear-gradient(90deg, ${barColor}55 0%, ${barColor}88 100%)`
+                          : status === "in_progress"
+                          ? `linear-gradient(90deg, ${barColor}44 0%, ${barColor}66 100%)`
+                          : `${barColor}22`,
+                      borderRadius: fillPercent === 100 ? 4 : "4px 0 0 4px",
                       pointerEvents: "none",
-                      transition: "width 0.3s",
+                      transition: "width 0.5s ease",
                     }}
                   />
                   {/* Label inside bar */}

--- a/src/lib/gantt/layout.ts
+++ b/src/lib/gantt/layout.ts
@@ -2,8 +2,10 @@
  * Gantt layout engine
  *
  * Maps SkillNode data (from Node3D) to horizontal time-bar positions.
- * Uses `properties.start_date`, `properties.due_date`, and `properties.estimate`
- * for positioning.  Falls back to relative ordering when dates are absent.
+ *
+ * Date priority (highest to lowest):
+ *   start: node.created_at → properties.start_date → relative ordering
+ *   end:   node.completed_at → properties.due_date → start + estimate → start + 7d
  *
  * Swimlane mode: rows are grouped by `properties.assignee`.  Each group gets a
  * labelled header band; tickets in each group are rendered in their own row.
@@ -138,8 +140,10 @@ export function computeGanttLayout(nodes: Node3D[]): GanttLayout {
   // Parse dates + assignee for each node
   const parsed: Parsed[] = nodes.map((n) => {
     const p = (n.data.properties ?? {}) as Record<string, string | null>;
-    const start = parseDate(p.start_date);
-    const end = parseDate(p.due_date);
+    // Prefer created_at (ticket open time) over manual start_date
+    const start = parseDate(n.data.created_at ?? null) ?? parseDate(p.start_date);
+    // Prefer completed_at (ticket close time) over manual due_date
+    const end = parseDate(n.data.completed_at ?? null) ?? parseDate(p.due_date);
     const estDays = parseEstimateDays(p.estimate);
 
     let resolvedEnd = end;

--- a/src/lib/store/tree-store.ts
+++ b/src/lib/store/tree-store.ts
@@ -292,14 +292,36 @@ export const useTreeStore = create<TreeState>((set, get) => ({
   },
 
   toggleNodeStatus: (nodeId) => {
+    // Compute next status and completed_at before updating state
+    const currentNode = get().nodes.find((n) => n.id === nodeId);
+    if (!currentNode) return;
+    const idx = STATUS_CYCLE.indexOf(currentNode.data.status);
+    const next = STATUS_CYCLE[(idx + 1) % STATUS_CYCLE.length];
+    const completedAt =
+      next === "completed" ? new Date().toISOString() : null;
+
     set((state) => ({
       nodes: state.nodes.map((n) => {
         if (n.id !== nodeId) return n;
-        const idx = STATUS_CYCLE.indexOf(n.data.status);
-        const next = STATUS_CYCLE[(idx + 1) % STATUS_CYCLE.length];
-        return { ...n, data: { ...n.data, status: next } };
+        return {
+          ...n,
+          data: {
+            ...n.data,
+            status: next,
+            completed_at: completedAt,
+          },
+        };
       }),
     }));
+
+    // Persist completed_at to DB
+    const supabase = createClient();
+    supabase
+      .from("skill_nodes")
+      .update({ completed_at: completedAt })
+      .eq("id", nodeId)
+      .eq("tree_id", currentNode.data.tree_id)
+      .then(() => {});
   },
 
   addEdge: async (input) => {

--- a/src/types/skill-tree.ts
+++ b/src/types/skill-tree.ts
@@ -32,6 +32,10 @@ export interface SkillNode {
   /** Flexible structured metadata (added in migration 004). Stored as jsonb in DB. */
   properties: Record<string, unknown>;
   content: import("./node-content").NodeContent;
+  /** ISO timestamp: when this node was created (ticket start for Gantt). */
+  created_at?: string;
+  /** ISO timestamp: when this node's status last became 'completed' (ticket end for Gantt). */
+  completed_at?: string | null;
 }
 
 /** Edge relationship type (added in migration 004). */

--- a/supabase/migrations/008_node_completed_at.sql
+++ b/supabase/migrations/008_node_completed_at.sql
@@ -1,0 +1,20 @@
+-- Migration 008: Add completed_at to skill_nodes
+-- Tracks when a node's status transitions to 'completed'.
+-- Used by Gantt view to render ticket duration bars (created_at → completed_at).
+--
+-- IMPORTANT: Apply via Supabase Dashboard SQL Editor or psql:
+--   psql $DATABASE_URL -f supabase/migrations/008_node_completed_at.sql
+
+ALTER TABLE skill_nodes
+  ADD COLUMN IF NOT EXISTS completed_at timestamptz;
+
+-- Backfill: for nodes already in 'completed' status, set completed_at = created_at
+-- (best approximation since we don't have the real timestamp)
+UPDATE skill_nodes
+  SET completed_at = created_at
+  WHERE status = 'completed' AND completed_at IS NULL;
+
+-- Index for Gantt queries that filter/sort by completed_at
+CREATE INDEX IF NOT EXISTS skill_nodes_completed_at_idx
+  ON skill_nodes (tree_id, completed_at)
+  WHERE completed_at IS NOT NULL;


### PR DESCRIPTION
## What was built and why

This ticket adds real ticket duration tracking to the Gantt view. Previously, bars were positioned using manual `start_date` / `due_date` properties. Now, bars use `created_at` (when the ticket was opened) as the start and a new `completed_at` timestamp (when the ticket was marked done) as the end — reflecting actual PM ticket lifecycle data.

## Key technical decisions

**New DB column:** `completed_at timestamptz` added to `skill_nodes` via migration 008. Auto-backfills `completed_at = created_at` for existing completed nodes as a best approximation.

**Date priority in Gantt:** `created_at` → `properties.start_date` for bar start; `completed_at` → `properties.due_date` for bar end. Real lifecycle timestamps take precedence, with graceful fallback to manual dates.

**Auto-tracking in store:** `toggleNodeStatus` now sets `completed_at = now()` when transitioning TO completed, and clears it when leaving. Persisted to Supabase immediately.

**Coloured duration fill:** Full gradient fill for completed (solid, known duration); elapsed-% fill for in_progress; empty for queued/locked. Added queued colour (violet #a78bfa).

## Files changed

- `supabase/migrations/008_node_completed_at.sql` — new migration: `completed_at` column + index + backfill
- `src/types/skill-tree.ts` — `created_at` and `completed_at` added to SkillNode
- `src/lib/gantt/layout.ts` — Gantt now prefers `node.created_at` / `node.completed_at` over manual properties
- `src/lib/store/tree-store.ts` — `toggleNodeStatus` sets/clears `completed_at` and persists to DB
- `src/components/canvas/GanttView.tsx` — updated bar fill, queued colour, gradient rendering
- `src/app/(app)/tree/[id]/page.tsx` — poll fetches `created_at` and `completed_at`

## How to verify

1. Apply migration 008 in Supabase dashboard
2. Open Gantt view — completed nodes bars span creation → completion date
3. Toggle a node to completed (Space) — DB `completed_at` is set
4. Toggle back — `completed_at` is cleared
5. In-progress nodes show elapsed-% fill based on bar duration