### PR TITLE
ITEM-143: Skill tree view redesign — bottom-up tree, phase nodes as branches

### DIFF
--- a/src/components/canvas/SkillTreeView2D.tsx
+++ b/src/components/canvas/SkillTreeView2D.tsx
@@ -7,33 +7,82 @@ import { NodeDetailPanel } from "@/components/panel/NodeDetailPanel";
 import { SearchPanel } from "./SearchPanel";
 
 // Node dimensions fed into dagre
-const NODE_W = 140;
-const NODE_H = 52;
-const RANK_SEP = 90; // vertical gap between dependency levels
-const NODE_SEP = 50; // horizontal gap between sibling nodes
+const NODE_W = 160;
+const NODE_H = 60;
+const PHASE_NODE_W_BASE = 160;
+const PHASE_NODE_H_BASE = 64;
+const RANK_SEP = 100; // vertical gap between dependency levels
+const NODE_SEP = 80;  // horizontal gap between sibling nodes (increased for breathing room)
 
 interface PositionedNode {
   id: string;
   node: Node3D;
   x: number;
   y: number;
+  w: number;
+  h: number;
 }
 
 interface PositionedEdge {
   id: string;
   type: string;
+  isPhaseEdge: boolean;
+  isCompletedPhase: boolean;
+  isActivePhase: boolean;
   points: { x: number; y: number }[];
 }
 
 const VIRTUAL_ROOT_ID = "__ROOT__";
 
+interface PhaseStats {
+  total: number;
+  done: number;
+  status: "completed" | "in_progress" | "locked";
+}
+
+function computePhaseStats(
+  phaseId: string,
+  allNodes: Node3D[]
+): PhaseStats {
+  const children = allNodes.filter(
+    (n) => n.data.parent_id === phaseId
+  );
+  const total = children.length;
+  const done = children.filter((n) => n.data.status === "completed").length;
+  const hasInProgress = children.some((n) => n.data.status === "in_progress");
+  let status: "completed" | "in_progress" | "locked" = "locked";
+  if (total > 0 && done === total) status = "completed";
+  else if (done > 0 || hasInProgress) status = "in_progress";
+  return { total, done, status };
+}
+
+/** Size a phase node proportional to ticket count (clamped). */
+function phaseNodeSize(total: number): { w: number; h: number } {
+  const scale = Math.min(1.8, Math.max(1, 1 + total * 0.04));
+  return {
+    w: Math.round(PHASE_NODE_W_BASE * scale),
+    h: Math.round(PHASE_NODE_H_BASE * scale),
+  };
+}
+
+/** Small deterministic x-offset per sibling to break perfect columns. */
+function organicOffset(id: string, index: number): number {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) hash = (hash * 31 + id.charCodeAt(i)) & 0xffff;
+  // Shift alternating left/right, capped at ±18px
+  const sign = index % 2 === 0 ? 1 : -1;
+  return sign * ((hash % 15) + 3);
+}
+
 function buildDagreLayout(
   nodes: Node3D[],
-  edges: { source_id: string; target_id: string; type: string; id: string }[]
+  edges: { source_id: string; target_id: string; type: string; id: string }[],
+  expandedPhaseIds: Set<string>,
+  allNodes: Node3D[]
 ): { posNodes: PositionedNode[]; posEdges: PositionedEdge[]; width: number; height: number } {
   const g = new dagre.graphlib.Graph();
   g.setGraph({
-    rankdir: "TB", // top-to-bottom dependency flow
+    rankdir: "BT", // bottom-to-top: root at bottom, phases branch upward
     ranksep: RANK_SEP,
     nodesep: NODE_SEP,
     marginx: 40,
@@ -41,80 +90,99 @@ function buildDagreLayout(
   });
   g.setDefaultEdgeLabel(() => ({}));
 
-  // Add virtual ROOT node (hidden — zero size so dagre treats it as a layout anchor)
-  g.setNode(VIRTUAL_ROOT_ID, { width: 0, height: 0 });
-
-  // Add all real nodes
+  // Precompute phase stats
+  const phaseStats = new Map<string, PhaseStats>();
   nodes.forEach((n) => {
-    g.setNode(n.id, { width: NODE_W, height: NODE_H });
+    const type = n.data.type ?? n.data.role;
+    if (type === "stellar") {
+      phaseStats.set(n.id, computePhaseStats(n.id, allNodes));
+    }
   });
 
-  // Prefer depends_on edges; fall back to parent_id edges when none exist
-  const depEdges = edges.filter((e) => e.type === "depends_on");
-  const blocksEdges = edges.filter((e) => e.type === "blocks");
-  const nodeIds = new Set(nodes.map((n) => n.id));
-  // Build a map from edge id → type so posEdges can carry it
-  const edgeTypeMap = new Map<string, string>(edges.map((e) => [e.id, e.type]));
+  // Add virtual ROOT node (hidden — zero size)
+  g.setNode(VIRTUAL_ROOT_ID, { width: 0, height: 0 });
 
-  if (depEdges.length > 0 || blocksEdges.length > 0) {
-    // depends_on: source depends on target → target is prerequisite → layout target above source
-    depEdges.forEach((e) => {
-      if (nodeIds.has(e.source_id) && nodeIds.has(e.target_id)) {
-        g.setEdge(e.target_id, e.source_id, { id: e.id });
-      }
-    });
-    // blocks: source blocks target → source must come before target → layout source above target
-    blocksEdges.forEach((e) => {
-      if (nodeIds.has(e.source_id) && nodeIds.has(e.target_id)) {
-        g.setEdge(e.source_id, e.target_id, { id: e.id });
-      }
-    });
-    // Connect stellars (nodes with no incoming dep-edge) to ROOT
-    const hasIncoming = new Set(depEdges.map((e) => e.source_id));
-    nodes.forEach((n) => {
-      if ((n.data.type ?? n.data.role) === "stellar" && !hasIncoming.has(n.id)) {
-        g.setEdge(VIRTUAL_ROOT_ID, n.id, { id: `${VIRTUAL_ROOT_ID}-${n.id}` });
-      }
-    });
-  } else {
-    // Fallback: use parent_id hierarchy as edges
-    nodes.forEach((n) => {
-      const parentId = n.data.parent_id;
-      if (parentId && nodeIds.has(parentId)) {
-        g.setEdge(parentId, n.id, { id: `${parentId}-${n.id}` });
-      }
-    });
-    // Connect all phase stellars (no parent_id) to ROOT
-    nodes.forEach((n) => {
-      if ((n.data.type ?? n.data.role) === "stellar" && !n.data.parent_id) {
-        g.setEdge(VIRTUAL_ROOT_ID, n.id, { id: `${VIRTUAL_ROOT_ID}-${n.id}` });
-      }
-    });
-  }
+  // Determine which nodes are visible:
+  // Level 1: stellar (phase) nodes only
+  // Level 2: if a phase is expanded, also show its planet children
+  const visibleNodes = nodes.filter((n) => {
+    const type = n.data.type ?? n.data.role;
+    if (type === "stellar") return true;
+    if (type === "planet") {
+      // Show if parent phase is expanded
+      return n.data.parent_id && expandedPhaseIds.has(n.data.parent_id);
+    }
+    // satellites not shown in this view
+    return false;
+  });
+
+  const nodeIds = new Set(visibleNodes.map((n) => n.id));
+  const nodeSizeMap = new Map<string, { w: number; h: number }>();
+
+  // Add all visible nodes with appropriate sizes
+  visibleNodes.forEach((n, idx) => {
+    const type = n.data.type ?? n.data.role;
+    if (type === "stellar") {
+      const stats = phaseStats.get(n.id) ?? { total: 0, done: 0, status: "locked" as const };
+      const { w, h } = phaseNodeSize(stats.total);
+      nodeSizeMap.set(n.id, { w, h });
+      g.setNode(n.id, { width: w, height: h });
+    } else {
+      nodeSizeMap.set(n.id, { w: NODE_W, h: NODE_H });
+      g.setNode(n.id, { width: NODE_W, height: NODE_H });
+    }
+  });
+
+  // Build edges: phase nodes → ROOT, planet nodes → phase node
+  visibleNodes.forEach((n, idx) => {
+    const type = n.data.type ?? n.data.role;
+    if (type === "stellar") {
+      // Phase → ROOT (BT: ROOT at bottom, phases above)
+      g.setEdge(VIRTUAL_ROOT_ID, n.id, { id: `${VIRTUAL_ROOT_ID}-${n.id}`, isPhaseEdge: true });
+    } else if (type === "planet" && n.data.parent_id && nodeIds.has(n.data.parent_id)) {
+      // Planet → Phase
+      g.setEdge(n.data.parent_id, n.id, { id: `${n.data.parent_id}-${n.id}`, isPhaseEdge: false });
+    }
+  });
 
   dagre.layout(g);
 
-  // Exclude virtual ROOT from rendered nodes
-  const posNodes: PositionedNode[] = nodes.map((n) => {
+  // Extract positioned nodes (exclude ROOT)
+  const posNodes: PositionedNode[] = visibleNodes.map((n, idx) => {
     const pos = g.node(n.id);
+    const { w, h } = nodeSizeMap.get(n.id) ?? { w: NODE_W, h: NODE_H };
+    const type = n.data.type ?? n.data.role;
+    // Apply organic x-offset only to phase (stellar) nodes
+    const xOff = type === "stellar" ? organicOffset(n.id, idx) : 0;
     return {
       id: n.id,
       node: n,
-      // dagre returns center coordinates; convert to top-left
-      x: pos.x - NODE_W / 2,
-      y: pos.y - NODE_H / 2,
+      x: pos.x - w / 2 + xOff,
+      y: pos.y - h / 2,
+      w,
+      h,
     };
   });
 
-  // Exclude edges connected to ROOT from rendered edges
+  // Extract positioned edges (exclude edges to/from ROOT)
   const posEdges: PositionedEdge[] = g.edges()
     .filter((e) => e.v !== VIRTUAL_ROOT_ID && e.w !== VIRTUAL_ROOT_ID)
     .map((e) => {
       const edgeObj = g.edge(e);
       const edgeId = edgeObj.id ?? `${e.v}-${e.w}`;
+      const sourceNode = visibleNodes.find((n) => n.id === e.v);
+      const targetNode = visibleNodes.find((n) => n.id === e.w);
+      const isPhaseEdge =
+        (sourceNode?.data.type ?? sourceNode?.data.role) === "stellar" &&
+        (targetNode?.data.type ?? targetNode?.data.role) === "planet";
+      const phaseId = isPhaseEdge ? e.v : e.w;
+      const stats = phaseStats.get(phaseId);
       return {
         id: edgeId,
-        type: edgeTypeMap.get(edgeId) ?? "depends_on",
+        type: "parent",
+        isPhaseEdge,
+        isCompletedPhase: stats?.status === "completed",
+        isActivePhase: stats?.status === "in_progress",
         points: edgeObj.points ?? [],
       };
     });
@@ -130,7 +198,6 @@ function pointsToPath(points: { x: number; y: number }[]): string {
   if (points.length < 2) return "";
   const [first, ...rest] = points;
   const parts = [`M ${first.x} ${first.y}`];
-  // Smooth cubic bezier through waypoints: join via midpoints as control points
   for (let i = 0; i < rest.length - 1; i++) {
     const p1 = rest[i];
     const p2 = rest[i + 1];
@@ -144,15 +211,22 @@ function pointsToPath(points: { x: number; y: number }[]): string {
 }
 
 const STATUS_COLORS: Record<string, string> = {
-  completed: "#34d399",  // green — matches glow
-  in_progress: "#f59e0b", // amber — matches pulse
-  locked: "#334155",      // dark/muted slate
+  completed: "#34d399",  // green
+  in_progress: "#f59e0b", // amber
+  locked: "#334155",      // dark slate
+  queued: "#60a5fa",      // blue
 };
 
-const TYPE_BORDER: Record<string, string> = {
-  stellar: "#818cf8",
-  planet: "#34d399",
-  satellite: "#94a3b8",
+const PHASE_GLOW: Record<string, string> = {
+  completed: "0 0 18px 4px rgba(52,211,153,0.55)",
+  in_progress: "0 0 16px 3px rgba(245,158,11,0.5)",
+  locked: "none",
+};
+
+const PHASE_BORDER: Record<string, string> = {
+  completed: "#34d399",
+  in_progress: "#f59e0b",
+  locked: "#334155",
 };
 
 export function SkillTreeView2D() {
@@ -162,85 +236,38 @@ export function SkillTreeView2D() {
   const setPinnedNode = useTreeStore((s) => s.setPinnedNode);
   const searchHighlightId = useTreeStore((s) => s.searchHighlightId);
 
+  // Two-level view: which phase nodes are expanded (showing their planets)
+  const [expandedPhaseIds, setExpandedPhaseIds] = useState<Set<string>>(new Set());
+
   // Pan/zoom state
   const [transform, setTransform] = useState({ x: 0, y: 40, scale: 1 });
   const isPanning = useRef(false);
   const lastPointer = useRef({ x: 0, y: 0 });
   const containerRef = useRef<HTMLDivElement>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
 
-  // Hover state for path highlighting
+  // Hover state
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
 
-  // Compute full unlock chain: ancestors (prereqs) + hovered node + descendants (dependents/blocked)
-  const hoveredChain = useMemo(() => {
-    if (!hoveredNodeId) return null;
-    const depEdges = edges.filter((e) => e.type === "depends_on" || e.type === "blocks");
-    const chain = new Set<string>([hoveredNodeId]);
-
-    // depends_on ancestors: source depends on target → follow target upward
-    const depOnlyEdges = edges.filter((e) => e.type === "depends_on");
-    const ancestorQueue = [hoveredNodeId];
-    while (ancestorQueue.length > 0) {
-      const current = ancestorQueue.shift()!;
-      depOnlyEdges.forEach((e) => {
-        if (e.source_id === current && !chain.has(e.target_id)) {
-          chain.add(e.target_id);
-          ancestorQueue.push(e.target_id);
-        }
-      });
-    }
-
-    // descendants: edges where target_id === current → source_id depends on / is blocked by this node
-    const descendantQueue = [hoveredNodeId];
-    while (descendantQueue.length > 0) {
-      const current = descendantQueue.shift()!;
-      depEdges.forEach((e) => {
-        if (e.target_id === current && !chain.has(e.source_id)) {
-          chain.add(e.source_id);
-          descendantQueue.push(e.source_id);
-        }
-      });
-    }
-
-    // blocks: source blocks target → follow forward
-    const blocksOnlyEdges = edges.filter((e) => e.type === "blocks");
-    const blockedQueue = [hoveredNodeId];
-    while (blockedQueue.length > 0) {
-      const current = blockedQueue.shift()!;
-      blocksOnlyEdges.forEach((e) => {
-        if (e.source_id === current && !chain.has(e.target_id)) {
-          chain.add(e.target_id);
-          blockedQueue.push(e.target_id);
-        }
-      });
-    }
-
-    return chain;
-  }, [hoveredNodeId, edges]);
-
-  // Set of edge IDs that connect nodes within the hovered chain (depends_on and blocks)
-  const chainEdgeIds = useMemo(() => {
-    if (!hoveredChain) return null;
-    const ids = new Set<string>();
-    edges.forEach((e) => {
-      if (
-        (e.type === "depends_on" || e.type === "blocks") &&
-        hoveredChain.has(e.source_id) &&
-        hoveredChain.has(e.target_id)
-      ) {
-        ids.add(e.id);
-      }
-    });
-    return ids;
-  }, [hoveredChain, edges]);
-
-  // Build dagre layout from dependency edges
+  // Build dagre layout
   const { posNodes, posEdges, svgWidth, svgHeight } = useMemo(() => {
-    const { posNodes, posEdges, width, height } = buildDagreLayout(nodes, edges);
+    const { posNodes, posEdges, width, height } = buildDagreLayout(nodes, edges, expandedPhaseIds, nodes);
     return { posNodes, posEdges, svgWidth: Math.max(width, 400), svgHeight: Math.max(height, 300) };
-  }, [nodes, edges]);
+  }, [nodes, edges, expandedPhaseIds]);
 
   const pinnedNode = useMemo(() => nodes.find((n) => n.id === pinnedNodeId), [nodes, pinnedNodeId]);
+
+  // Fit-to-screen handler
+  const fitToScreen = useCallback(() => {
+    if (!containerRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    const scaleX = rect.width / svgWidth;
+    const scaleY = rect.height / svgHeight;
+    const scale = Math.min(scaleX, scaleY, 1) * 0.9;
+    const x = (rect.width - svgWidth * scale) / 2;
+    const y = (rect.height - svgHeight * scale) / 2;
+    setTransform({ x, y, scale });
+  }, [svgWidth, svgHeight]);
 
   // Pointer events for panning
   const onPointerDown = useCallback((e: React.PointerEvent) => {
@@ -266,7 +293,7 @@ export function SkillTreeView2D() {
     e.preventDefault();
     const factor = e.deltaY < 0 ? 1.1 : 0.9;
     setTransform((t) => {
-      const newScale = Math.min(2.5, Math.max(0.25, t.scale * factor));
+      const newScale = Math.min(2.5, Math.max(0.2, t.scale * factor));
       const rect = containerRef.current?.getBoundingClientRect();
       if (!rect) return { ...t, scale: newScale };
       const mx = e.clientX - rect.left;
@@ -276,6 +303,21 @@ export function SkillTreeView2D() {
       return { x: newX, y: newY, scale: newScale };
     });
   }, []);
+
+  // Handle phase node click: toggle expansion
+  const handleNodeClick = useCallback((node: Node3D, nodeId: string) => {
+    const type = node.data.type ?? node.data.role;
+    if (type === "stellar") {
+      setExpandedPhaseIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(nodeId)) next.delete(nodeId);
+        else next.add(nodeId);
+        return next;
+      });
+    } else {
+      setPinnedNode(pinnedNodeId === nodeId ? null : nodeId);
+    }
+  }, [pinnedNodeId, setPinnedNode]);
 
   return (
     <div
@@ -288,8 +330,20 @@ export function SkillTreeView2D() {
       onPointerLeave={onPointerUp}
       onWheel={onWheel}
     >
+      {/* CSS animations for pulsing amber edge */}
+      <style>{`
+        @keyframes pulse-amber {
+          0%, 100% { stroke-opacity: 0.9; stroke-width: 2.5px; }
+          50% { stroke-opacity: 0.4; stroke-width: 1.5px; }
+        }
+        .edge-active-phase {
+          animation: pulse-amber 1.8s ease-in-out infinite;
+        }
+      `}</style>
+
       {/* SVG layer for edges */}
       <svg
+        ref={svgRef}
         style={{
           position: "absolute",
           left: 0,
@@ -300,80 +354,23 @@ export function SkillTreeView2D() {
           overflow: "visible",
         }}
       >
-        <defs>
-          {/* depends_on default */}
-          <marker
-            id="arrowhead"
-            markerWidth="10"
-            markerHeight="7"
-            refX="9"
-            refY="3.5"
-            orient="auto"
-          >
-            <polygon points="0 0, 10 3.5, 0 7" fill="rgba(148,163,184,0.85)" />
-          </marker>
-          {/* depends_on highlighted (chain) */}
-          <marker
-            id="arrowhead-chain"
-            markerWidth="10"
-            markerHeight="7"
-            refX="9"
-            refY="3.5"
-            orient="auto"
-          >
-            <polygon points="0 0, 10 3.5, 0 7" fill="#818cf8" />
-          </marker>
-          {/* blocks default — red */}
-          <marker
-            id="arrowhead-blocks"
-            markerWidth="10"
-            markerHeight="7"
-            refX="9"
-            refY="3.5"
-            orient="auto"
-          >
-            <polygon points="0 0, 10 3.5, 0 7" fill="rgba(248,113,113,0.85)" />
-          </marker>
-          {/* blocks highlighted — bright red */}
-          <marker
-            id="arrowhead-blocks-chain"
-            markerWidth="10"
-            markerHeight="7"
-            refX="9"
-            refY="3.5"
-            orient="auto"
-          >
-            <polygon points="0 0, 10 3.5, 0 7" fill="#f87171" />
-          </marker>
-        </defs>
         <g transform={`translate(${transform.x},${transform.y}) scale(${transform.scale})`}>
           {posEdges.map((edge) => {
             const d = pointsToPath(edge.points);
             if (!d) return null;
-            const isChainEdge = chainEdgeIds ? chainEdgeIds.has(edge.id) : false;
-            const isDimmed = hoveredNodeId !== null && !isChainEdge;
-            const isBlocks = edge.type === "blocks";
-            // Stroke colour: blocks=red, depends_on=violet/slate
-            const stroke = isChainEdge
-              ? (isBlocks ? "#f87171" : "#818cf8")
-              : (isBlocks ? "rgba(248,113,113,0.7)" : "rgba(148,163,184,0.7)");
-            // Arrowhead marker
-            const markerEnd = isChainEdge
-              ? (isBlocks ? "url(#arrowhead-blocks-chain)" : "url(#arrowhead-chain)")
-              : (isBlocks ? "url(#arrowhead-blocks)" : "url(#arrowhead)");
-            // Dashed stroke for blocks edges to visually distinguish from depends_on
-            const strokeDasharray = isBlocks ? "6 3" : undefined;
+            const stroke = edge.isCompletedPhase
+              ? "#34d399"
+              : edge.isActivePhase
+              ? "#f59e0b"
+              : "rgba(100,116,139,0.5)";
             return (
               <path
                 key={edge.id}
                 d={d}
                 fill="none"
                 stroke={stroke}
-                strokeWidth={isChainEdge ? 2.5 : 1.5}
-                strokeOpacity={isDimmed ? 0.15 : 1}
-                strokeDasharray={strokeDasharray}
-                markerEnd={markerEnd}
-                style={{ transition: "stroke-opacity 0.15s, stroke-width 0.15s" }}
+                strokeWidth={edge.isCompletedPhase ? 2.5 : edge.isActivePhase ? 2.5 : 1.5}
+                className={edge.isActivePhase ? "edge-active-phase" : undefined}
               />
             );
           })}
@@ -392,44 +389,163 @@ export function SkillTreeView2D() {
           height: svgHeight,
         }}
       >
-        {posNodes.map(({ id, node, x, y }) => {
+        {posNodes.map(({ id, node, x, y, w, h }) => {
           const type = node.data.type ?? node.data.role;
           const status = node.data.status;
           const isHighlighted = id === searchHighlightId;
           const isPinned = id === pinnedNodeId;
-          const isInChain = hoveredChain ? hoveredChain.has(id) : false;
           const isHovered = id === hoveredNodeId;
-          const isDimmedByHover = hoveredNodeId !== null && !isInChain;
+          const isExpanded = expandedPhaseIds.has(id);
+          const isPhase = type === "stellar";
 
-          // Determine glow class based on status (only when not overridden by pin/highlight/hover)
-          const glowClass = isPinned || isHighlighted || isInChain
-            ? ""
-            : `node-status-${status}`;
+          if (isPhase) {
+            // Compute phase stats for display
+            const stats: PhaseStats = (() => {
+              const children = nodes.filter((n) => n.data.parent_id === id);
+              const total = children.length;
+              const done = children.filter((n) => n.data.status === "completed").length;
+              const hasInProgress = children.some((n) => n.data.status === "in_progress");
+              let st: "completed" | "in_progress" | "locked" = "locked";
+              if (total > 0 && done === total) st = "completed";
+              else if (done > 0 || hasInProgress) st = "in_progress";
+              return { total, done, status: st };
+            })();
 
+            const borderColor = isHighlighted
+              ? "#f59e0b"
+              : PHASE_BORDER[stats.status] ?? "#334155";
+            const glow = isHovered
+              ? "0 0 20px 5px rgba(129,140,248,0.6)"
+              : PHASE_GLOW[stats.status] ?? "none";
+            const completionPct = stats.total > 0 ? Math.round((stats.done / stats.total) * 100) : 0;
+            const phaseName = node.data.label;
+
+            return (
+              <div
+                key={id}
+                data-node="true"
+                onClick={() => handleNodeClick(node, id)}
+                onMouseEnter={() => setHoveredNodeId(id)}
+                onMouseLeave={() => setHoveredNodeId(null)}
+                style={{
+                  position: "absolute",
+                  left: x,
+                  top: y,
+                  width: w,
+                  height: h,
+                  borderRadius: 12,
+                  border: `2px solid ${borderColor}`,
+                  background: isHovered
+                    ? "rgba(30,41,59,0.95)"
+                    : stats.status === "completed"
+                    ? "rgba(15,35,30,0.92)"
+                    : stats.status === "in_progress"
+                    ? "rgba(30,25,15,0.92)"
+                    : "rgba(10,14,26,0.92)",
+                  boxShadow: glow,
+                  cursor: "pointer",
+                  userSelect: "none",
+                  display: "flex",
+                  flexDirection: "column",
+                  justifyContent: "center",
+                  padding: "8px 12px",
+                  gap: 4,
+                  transition: "border-color 0.2s, box-shadow 0.2s, background 0.2s",
+                }}
+              >
+                {/* Phase label */}
+                <div
+                  style={{
+                    fontSize: 12,
+                    fontFamily: "monospace",
+                    fontWeight: 700,
+                    color: stats.status === "completed"
+                      ? "#34d399"
+                      : stats.status === "in_progress"
+                      ? "#f59e0b"
+                      : "#94a3b8",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                  title={phaseName}
+                >
+                  {phaseName}
+                </div>
+                {/* Stats row */}
+                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  <span
+                    style={{
+                      fontSize: 10,
+                      fontFamily: "monospace",
+                      color: "#64748b",
+                    }}
+                  >
+                    {stats.done}/{stats.total} done
+                  </span>
+                  {/* Completion bar */}
+                  <div
+                    style={{
+                      flex: 1,
+                      height: 4,
+                      borderRadius: 2,
+                      background: "rgba(71,85,105,0.4)",
+                      overflow: "hidden",
+                    }}
+                  >
+                    <div
+                      style={{
+                        height: "100%",
+                        width: `${completionPct}%`,
+                        borderRadius: 2,
+                        background: stats.status === "completed"
+                          ? "#34d399"
+                          : stats.status === "in_progress"
+                          ? "#f59e0b"
+                          : "#334155",
+                        transition: "width 0.3s",
+                      }}
+                    />
+                  </div>
+                  {/* Expand indicator */}
+                  <span
+                    style={{
+                      fontSize: 9,
+                      color: "#475569",
+                      transform: isExpanded ? "rotate(180deg)" : "none",
+                      transition: "transform 0.2s",
+                      display: "inline-block",
+                    }}
+                  >
+                    ▲
+                  </span>
+                </div>
+              </div>
+            );
+          }
+
+          // Planet (ticket) node
           return (
             <div
               key={id}
               data-node="true"
-              onClick={() => setPinnedNode(isPinned ? null : id)}
+              onClick={() => handleNodeClick(node, id)}
               onMouseEnter={() => setHoveredNodeId(id)}
               onMouseLeave={() => setHoveredNodeId(null)}
-              className={glowClass}
               style={{
                 position: "absolute",
                 left: x,
                 top: y,
-                width: NODE_W,
-                height: NODE_H,
+                width: w,
+                height: h,
                 borderRadius: 8,
                 border: isHovered
                   ? "2px solid #a5b4fc"
-                  : isInChain
-                  ? "1.5px solid #818cf8"
-                  : `1.5px solid ${isPinned ? "#818cf8" : TYPE_BORDER[type] ?? "#475569"}`,
+                  : isPinned
+                  ? "2px solid #818cf8"
+                  : `1.5px solid ${STATUS_COLORS[status] ?? "#475569"}`,
                 background: isHovered
                   ? "rgba(99,102,241,0.28)"
-                  : isInChain
-                  ? "rgba(99,102,241,0.12)"
                   : isPinned
                   ? "rgba(99,102,241,0.18)"
                   : status === "locked"
@@ -439,8 +555,6 @@ export function SkillTreeView2D() {
                   ? "0 0 0 3px #f59e0b"
                   : isHovered
                   ? "0 0 10px rgba(129,140,248,0.6)"
-                  : isInChain
-                  ? "0 0 6px rgba(129,140,248,0.3)"
                   : isPinned
                   ? "0 0 0 2px rgba(129,140,248,0.5)"
                   : undefined,
@@ -451,11 +565,10 @@ export function SkillTreeView2D() {
                 justifyContent: "center",
                 padding: "6px 10px",
                 gap: 3,
-                transition: "border-color 0.15s, background 0.15s, box-shadow 0.15s, opacity 0.15s",
-                opacity: isDimmedByHover ? 0.25 : status === "locked" ? 0.55 : 1,
+                transition: "border-color 0.15s, background 0.15s, box-shadow 0.15s",
+                opacity: status === "locked" ? 0.55 : 1,
               }}
             >
-              {/* Label */}
               <div
                 style={{
                   fontSize: 11,
@@ -470,7 +583,6 @@ export function SkillTreeView2D() {
               >
                 {node.data.label}
               </div>
-              {/* Status + type badges */}
               <div style={{ display: "flex", gap: 4, alignItems: "center" }}>
                 <span
                   style={{
@@ -491,13 +603,44 @@ export function SkillTreeView2D() {
                     letterSpacing: "0.05em",
                   }}
                 >
-                  {type}
+                  {status}
                 </span>
               </div>
             </div>
           );
         })}
       </div>
+
+      {/* Fit-to-screen button */}
+      <button
+        onClick={fitToScreen}
+        style={{
+          position: "absolute",
+          top: 12,
+          right: 12,
+          background: "rgba(15,22,41,0.85)",
+          border: "1px solid #334155",
+          borderRadius: 6,
+          color: "#94a3b8",
+          fontSize: 11,
+          fontFamily: "monospace",
+          padding: "5px 10px",
+          cursor: "pointer",
+          zIndex: 10,
+          transition: "border-color 0.15s, color 0.15s",
+        }}
+        onMouseEnter={(e) => {
+          (e.currentTarget as HTMLButtonElement).style.borderColor = "#818cf8";
+          (e.currentTarget as HTMLButtonElement).style.color = "#a5b4fc";
+        }}
+        onMouseLeave={(e) => {
+          (e.currentTarget as HTMLButtonElement).style.borderColor = "#334155";
+          (e.currentTarget as HTMLButtonElement).style.color = "#94a3b8";
+        }}
+        title="Fit all phases to screen"
+      >
+        ⊞ Fit
+      </button>
 
       {/* Reuse detail panel and search from solar view */}
       {pinnedNode && (
@@ -511,7 +654,7 @@ export function SkillTreeView2D() {
 
       {/* Hint */}
       <div className="absolute bottom-4 left-4 text-[10px] text-slate-600 pointer-events-none">
-        Click node to pin details · Drag to pan · Scroll to zoom · / to search
+        Click phase to expand · Click ticket to pin details · Drag to pan · Scroll to zoom · / to search
       </div>
     </div>
   );


### PR DESCRIPTION
## ITEM-143: Skill Tree View Redesign — Bottom-Up Tree, Phase Nodes as Branches

### What was built and why

The 2D skill tree view (`SkillTreeView2D`) has been redesigned to display the project development history as a living, organic tree. The root sits at the bottom and phases branch upward, giving a natural growth metaphor for project progression.

### Key technical decisions

- **Bottom-up layout (`BT`):** Changed dagre `rankdir` from `TB` to `BT` — the virtual ROOT sits at the bottom, stellar (phase) nodes branch above it, and planet (ticket) nodes expand above their phase.
- **Two-level progressive disclosure:** Level 1 (default) shows only stellar/phase nodes for a clean overview. Clicking a phase toggles expansion to reveal its planet/ticket children (Level 2). This keeps the canvas uncluttered while still allowing drill-down.
- **Phase node enhancements:** Phase nodes are dynamically sized proportional to their ticket count (clamped scale 1.0–1.8×). They display a progress bar, completion ratio (`X/Y done`), and an expand/collapse indicator arrow. Color theming is driven by completion status: green glow for fully done, amber for in-progress, dark slate for locked.
- **Edge styling by phase status:** Phase-connecting edges use solid bright green (completed), pulsing amber CSS animation (active/in-progress), or subtle grey (locked/not started).
- **Organic x-offset variance:** A deterministic hash-based offset is applied to sibling phase nodes to break perfect grid columns and give a more natural branching feel. `NODE_SEP` increased from 50 → 80 for breathing room.
- **Fit-to-screen button:** A compact button in the top-right corner calculates the optimal scale + translation to fit all visible nodes within the viewport.

### Files changed

- **`src/components/canvas/SkillTreeView2D.tsx`** — Complete redesign:
  - `buildDagreLayout`: `rankdir` → `BT`, `NODE_SEP` → 80, added visible-node filtering (phase-only by default, planets shown when phase expanded), phase node dynamic sizing, organic x-offset, phase-aware edge metadata
  - New helpers: `computePhaseStats`, `phaseNodeSize`, `organicOffset`
  - New state: `expandedPhaseIds` (Set tracking which phases are expanded)
  - Phase node renderer: dynamic size, completion bar, status-colored glow/border, expand indicator
  - Planet node renderer: simplified (no hover chain, just pin-on-click)
  - `fitToScreen` button added to canvas
  - CSS keyframe animation (`pulse-amber`) injected via `<style>` tag for active phase edges
  - Hint text updated to reflect new interaction model