### PR TITLE
ITEM-148: AI assistant — clear conversation history command

### DIFF
--- a/src/app/(app)/tree/[id]/page.tsx
+++ b/src/app/(app)/tree/[id]/page.tsx
@@ -5,7 +5,11 @@ import { createClient } from "@/lib/supabase/client";
 import { useTreeStore, layoutGalaxy } from "@/lib/store/tree-store";
 import { useChatStore } from "@/lib/store/chat-store";
 import { SkillTreeCanvas } from "@/components/canvas/SkillTreeCanvas";
+<<<<<<< HEAD
 import { GanttView } from "@/components/canvas/GanttView";
+=======
+import { TimelineView } from "@/components/canvas/TimelineView";
+>>>>>>> item-150-impl
 import { WeightGraphView } from "@/components/canvas/WeightGraphView";
 import { KanbanView } from "@/components/canvas/KanbanView";
 import { CanvasErrorBoundary } from "@/components/ui/CanvasErrorBoundary";
@@ -235,7 +239,7 @@ export default function TreePage({ params }: { params: Promise<{ id: string }> }
               <SkillTreeCanvas />
             </CanvasErrorBoundary>
           ) : viewMode === "gantt" ? (
-            <GanttView />
+            <TimelineView />
           ) : viewMode === "weight" ? (
             <WeightGraphView />
           ) : (

--- a/src/components/canvas/SkillTreeCanvas.tsx
+++ b/src/components/canvas/SkillTreeCanvas.tsx
@@ -52,8 +52,12 @@ function OrthoZoomSync() {
 function CameraController() {
   const { camera } = useThree();
   const controlsRef = useRef<any>(null);
+  const viewMode = useTreeStore((s) => s.viewMode);
   const focusTargetId = useTreeStore((s) => s.focusTargetId);
   const trackingNodeId = useTreeStore((s) => s.trackingNodeId);
+
+  // In graph mode, camera is handled by GraphCameraController — do nothing
+  if (viewMode === "graph") return null;
   const topDownMode = useTreeStore((s) => s.topDownMode);
   const nodes = useTreeStore((s) => s.nodes);
   const setFocusTarget = useTreeStore((s) => s.setFocusTarget);
@@ -217,12 +221,40 @@ const STATUS_COLORS: Record<string, string> = {
   locked:      "#1e293b",
 };
 
+<<<<<<< HEAD
 /** Compute flat 2D graph positions: stellars in a circle, planets near their stellar */
+=======
+/** Compute flat 2D graph positions — Option B: timeline growth rings
+ *  Earlier completed phases/tickets sit closer to centre (like tree rings).
+ *  Locked/pending work lives at the outer edge.
+ *  Within each ring, nodes spread angularly with organic jitter.
+ */
+
+function seededRand(seed: string, offset = 0): number {
+  let h = offset * 2654435761;
+  for (let i = 0; i < seed.length; i++) {
+    h = Math.imul(h ^ seed.charCodeAt(i), 2654435761);
+  }
+  return ((h >>> 0) % 10000) / 10000;
+}
+
+function getCompletedAt(node: Node3D): number {
+  const props = (node.data.properties ?? {}) as Record<string, unknown>;
+  const ts = props.completed_at as string | undefined;
+  if (ts) return new Date(ts).getTime();
+  // Fallback: use phase number as proxy for age (lower phase = older)
+  const phase = props.phase as number | undefined;
+  if (phase) return phase * 1000; // older phases get smaller timestamps
+  return Date.now() + 1e12; // unfinished = far future
+}
+
+>>>>>>> item-150-impl
 function computeGraphPositions(nodes: Node3D[]): Map<string, [number, number, number]> {
   const pos = new Map<string, [number, number, number]>();
   const stellars = nodes.filter((n) => (n.data.type ?? n.data.role) === "stellar");
   const planets = nodes.filter((n) => (n.data.type ?? n.data.role) !== "stellar");
 
+<<<<<<< HEAD
   const stellarRadius = Math.max(8, stellars.length * 2.5);
 
   stellars.forEach((stellar, i) => {
@@ -236,11 +268,64 @@ function computeGraphPositions(nodes: Node3D[]): Map<string, [number, number, nu
   const planetsByParent = new Map<string, Node3D[]>();
   planets.forEach((p) => {
     const parentId = p.data.parent_id ?? "__root__";
+=======
+  // Sort stellars by completion time — earlier = closer to centre
+  const sortedStellars = [...stellars].sort((a, b) => getCompletedAt(a) - getCompletedAt(b));
+  const totalStellars = sortedStellars.length;
+
+  // Map each stellar to a ring radius based on completion order
+  // First completed = r=6, last/pending = r=28
+  const stellarRings = new Map<string, number>();
+  sortedStellars.forEach((s, i) => {
+    const t = totalStellars > 1 ? i / (totalStellars - 1) : 0.5;
+    // Eased: earlier phases bunch up near centre, later phases spread out
+    const r = 6 + Math.pow(t, 0.7) * 22;
+    stellarRings.set(s.id, r);
+  });
+
+  // Place stellars around their ring — angle spread evenly but with jitter
+  // Group by approximate ring (within 3 units = same ring)
+  const angleByRing = new Map<number, number[]>();
+  sortedStellars.forEach((s) => {
+    const r = stellarRings.get(s.id)!;
+    const ringKey = Math.round(r);
+    if (!angleByRing.has(ringKey)) angleByRing.set(ringKey, []);
+    angleByRing.get(ringKey)!.push(0);
+  });
+
+  // Assign angles — distribute evenly, grouped by ring
+  const ringCounts = new Map<number, { count: number; idx: number }>();
+  sortedStellars.forEach((s) => {
+    const r = Math.round(stellarRings.get(s.id)!);
+    if (!ringCounts.has(r)) ringCounts.set(r, { count: 0, idx: 0 });
+    ringCounts.get(r)!.count++;
+  });
+
+  sortedStellars.forEach((stellar) => {
+    const r = stellarRings.get(stellar.id)!;
+    const ringKey = Math.round(r);
+    const rc = ringCounts.get(ringKey)!;
+    const baseAngle = (rc.idx / rc.count) * Math.PI * 2 - Math.PI / 2;
+    rc.idx++;
+
+    const jitterAngle = (seededRand(stellar.id, 0) - 0.5) * (Math.PI / rc.count) * 0.5;
+    const jitterR = (seededRand(stellar.id, 1) - 0.5) * 1.5;
+    const angle = baseAngle + jitterAngle;
+    pos.set(stellar.id, [Math.cos(angle) * (r + jitterR), 0, Math.sin(angle) * (r + jitterR)]);
+  });
+
+  // Group planets by parent, also sorted by completion time
+  const planetsByParent = new Map<string, Node3D[]>();
+  planets.forEach((p) => {
+    const parentId = p.data.parent_id;
+    if (!parentId || !pos.has(parentId)) return;
+>>>>>>> item-150-impl
     if (!planetsByParent.has(parentId)) planetsByParent.set(parentId, []);
     planetsByParent.get(parentId)!.push(p);
   });
 
   planetsByParent.forEach((children, parentId) => {
+<<<<<<< HEAD
     const parentPos = pos.get(parentId) ?? [0, 0, 0];
     const r = 3.5;
     children.forEach((child, i) => {
@@ -255,6 +340,42 @@ function computeGraphPositions(nodes: Node3D[]): Map<string, [number, number, nu
   nodes.forEach((n) => {
     if (!pos.has(n.id)) {
       pos.set(n.id, [Math.random() * 4 - 2, 0, Math.random() * 4 - 2]);
+=======
+    const parentPos = pos.get(parentId)!;
+    const parentR = Math.sqrt(parentPos[0] ** 2 + parentPos[2] ** 2);
+    const baseAngle = Math.atan2(parentPos[2], parentPos[0]);
+
+    // Sort children by completion time — earlier = closer to phase
+    const sorted = [...children].sort((a, b) => getCompletedAt(a) - getCompletedAt(b));
+    const arcWidth = Math.min(Math.PI * 0.5, 0.2 + (sorted.length / 8) * Math.PI * 0.35);
+
+    sorted.forEach((child, i) => {
+      const row = Math.floor(i / 5);
+      const col = i % 5;
+      const rowCount = Math.min(5, sorted.length - row * 5);
+      const t = rowCount === 1 ? 0.5 : col / (rowCount - 1);
+
+      const rowArcWidth = arcWidth * (1 + row * 0.15);
+      const angle = baseAngle - rowArcWidth / 2 + t * rowArcWidth;
+
+      // Distance: completed tickets closer to parent, pending farther
+      const isComplete = child.data.status === "completed";
+      const baseR = parentR + 4.5 + row * 3.5 + (isComplete ? 0 : 1.5);
+      const rJitter = (seededRand(child.id, 2) - 0.5) * 1.5;
+      const aJitter = (seededRand(child.id, 3) - 0.5) * 0.2;
+      const r = baseR + rJitter;
+
+      pos.set(child.id, [Math.cos(angle + aJitter) * r, 0, Math.sin(angle + aJitter) * r]);
+    });
+  });
+
+  // Unpositioned nodes: scatter at outer edge
+  nodes.forEach((n) => {
+    if (!pos.has(n.id)) {
+      const a = seededRand(n.id, 0) * Math.PI * 2;
+      const r = 30 + seededRand(n.id, 1) * 5;
+      pos.set(n.id, [Math.cos(a) * r, 0, Math.sin(a) * r]);
+>>>>>>> item-150-impl
     }
   });
 
@@ -316,6 +437,7 @@ function GraphNode({
 }
 
 /** Graph mode edges */
+<<<<<<< HEAD
 function GraphEdges({ nodes, positions, edges }: { nodes: Node3D[]; positions: Map<string, [number, number, number]>; edges: import("@/types/skill-tree").SkillEdge[] }) {
   const nodeMap = useMemo(() => {
     const m = new Map<string, Node3D>();
@@ -341,6 +463,62 @@ function GraphEdges({ nodes, positions, edges }: { nodes: Node3D[]; positions: M
           />
         );
       })}
+=======
+const EDGE_COLORS: Record<string, string> = {
+  completed: "#22c55e",
+  in_progress: "#f59e0b",
+  queued: "#6366f1",
+  locked: "#1e293b",
+};
+
+function GraphEdges({ nodes, positions, edges }: { nodes: Node3D[]; positions: Map<string, [number, number, number]>; edges: import("@/types/skill-tree").SkillEdge[] }) {
+  const ROOT_POS: [number, number, number] = [0, 0, 0];
+
+  const lines = useMemo(() => {
+    const result: { key: string; from: [number,number,number]; to: [number,number,number]; color: string; width: number }[] = [];
+    const nodeMap = new Map<string, Node3D>(nodes.map((n) => [n.id, n]));
+
+    // 1. ROOT → each stellar
+    nodes.filter((n) => (n.data.type ?? n.data.role) === "stellar").forEach((s) => {
+      const to = positions.get(s.id);
+      if (!to) return;
+      const color = s.data.status === "completed" ? "#22d3ee33" : "#1e293b";
+      result.push({ key: `root-${s.id}`, from: ROOT_POS, to, color, width: 0.5 });
+    });
+
+    // 2. stellar → planets (parent lines)
+    nodes.filter((n) => (n.data.type ?? n.data.role) !== "stellar").forEach((p) => {
+      if (!p.data.parent_id) return;
+      const from = positions.get(p.data.parent_id);
+      const to = positions.get(p.id);
+      if (!from || !to) return;
+      const color = p.data.status === "completed"
+        ? EDGE_COLORS.completed + "66"
+        : p.data.status === "in_progress"
+        ? EDGE_COLORS.in_progress + "99"
+        : "#1e2a3a";
+      result.push({ key: `parent-${p.id}`, from, to, color, width: p.data.status === "completed" ? 0.8 : 0.4 });
+    });
+
+    // 3. depends_on edges — brighter, show relationships
+    edges.filter((e) => e.type === "depends_on").forEach((e) => {
+      const from = positions.get(e.source_id);
+      const to = positions.get(e.target_id);
+      if (!from || !to) return;
+      const src = nodeMap.get(e.source_id);
+      const color = src?.data.status === "completed" ? "#22c55e44" : "#3b4a5a";
+      result.push({ key: `dep-${e.id}`, from, to, color, width: 0.6 });
+    });
+
+    return result;
+  }, [nodes, positions, edges]);
+
+  return (
+    <>
+      {lines.map(({ key, from, to, color, width }) => (
+        <Line key={key} points={[from, to]} color={color} lineWidth={width} />
+      ))}
+>>>>>>> item-150-impl
     </>
   );
 }
@@ -349,7 +527,11 @@ function GraphEdges({ nodes, positions, edges }: { nodes: Node3D[]; positions: M
 function GraphCameraController() {
   const controlsRef = useRef<any>(null);
   const { camera, size } = useThree();
+<<<<<<< HEAD
   const [zoom, setZoom] = useState(30);
+=======
+  const [zoom, setZoom] = useState(55);
+>>>>>>> item-150-impl
 
   useEffect(() => {
     if (!(camera instanceof THREE.OrthographicCamera)) return;
@@ -392,7 +574,11 @@ function GraphScene() {
   const nodes = useTreeStore((s) => s.nodes);
   const edges = useTreeStore((s) => s.edges);
   const { camera, size } = useThree();
+<<<<<<< HEAD
   const [camZoom, setCamZoom] = useState(30);
+=======
+  const [camZoom, setCamZoom] = useState(55);
+>>>>>>> item-150-impl
 
   const positions = useMemo(() => computeGraphPositions(nodes), [nodes]);
 

--- a/src/components/canvas/TimelineView.tsx
+++ b/src/components/canvas/TimelineView.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useTreeStore } from "@/lib/store/tree-store";
+import { NodeDetailPanel } from "@/components/panel/NodeDetailPanel";
+import type { Node3D } from "@/lib/store/tree-store";
+import { sfxPanelOpen } from "@/lib/sfx";
+
+const STATUS_ICON: Record<string, string> = {
+  completed:   "✅",
+  in_progress: "⚡",
+  queued:      "⏳",
+  locked:      "🔒",
+};
+
+const STATUS_COLOR: Record<string, string> = {
+  completed:   "#22c55e",
+  in_progress: "#f59e0b",
+  queued:      "#6366f1",
+  locked:      "#475569",
+};
+
+function formatDate(ts: string | undefined | null): string {
+  if (!ts) return "";
+  const d = new Date(ts);
+  if (isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+function getNodeDate(node: Node3D): string | null {
+  const props = (node.data.properties ?? {}) as Record<string, unknown>;
+  // For completed nodes: use completed_at, then created_at
+  if (node.data.status === "completed") {
+    return (props.completed_at ?? props.created_at ?? null) as string | null;
+  }
+  // For non-completed: no date → goes to Pending
+  return null;
+}
+
+function getDateKey(ts: string | null): string {
+  if (!ts) return "Pending";
+  const d = new Date(ts);
+  if (isNaN(d.getTime())) return "Pending";
+  return d.toISOString().slice(0, 10);
+}
+
+function getPhaseName(node: Node3D): string {
+  const props = (node.data.properties ?? {}) as Record<string, unknown>;
+  const name = props.phase_name as string | undefined;
+  const num = props.phase as number | undefined;
+  if (name) return num ? `Phase ${num} · ${name}` : name;
+  return "";
+}
+
+interface PhaseGroup {
+  phaseKey: string;
+  phaseLabel: string;
+  color: string;
+  nodes: Node3D[];
+}
+
+interface TimelineGroup {
+  dateKey: string;
+  dateLabel: string;
+  phases: PhaseGroup[];
+}
+
+export function TimelineView() {
+  const nodes = useTreeStore((s) => s.nodes);
+  const pinnedNodeId = useTreeStore((s) => s.pinnedNodeId);
+  const setPinnedNode = useTreeStore((s) => s.setPinnedNode);
+  const [filter, setFilter] = useState<"all" | "completed" | "pending">("all");
+
+  const pinnedNode = useMemo(
+    () => nodes.find((n) => n.id === pinnedNodeId) ?? null,
+    [nodes, pinnedNodeId]
+  );
+
+  // Only planet nodes (tickets)
+  const tickets = useMemo(() =>
+    nodes.filter((n) => (n.data.type ?? n.data.role) !== "stellar"),
+    [nodes]
+  );
+
+  // Apply filter
+  const filtered = useMemo(() => {
+    if (filter === "completed") return tickets.filter((n) => n.data.status === "completed");
+    if (filter === "pending") return tickets.filter((n) => n.data.status !== "completed");
+    return tickets;
+  }, [tickets, filter]);
+
+  // Group by date
+  const groups = useMemo((): TimelineGroup[] => {
+    const map = new Map<string, Node3D[]>();
+
+    filtered.forEach((n) => {
+      const dateKey = getDateKey(getNodeDate(n));
+      if (!map.has(dateKey)) map.set(dateKey, []);
+      map.get(dateKey)!.push(n);
+    });
+
+    // Sort groups: dated ones chronologically, "Pending" at end
+    const entries = Array.from(map.entries()).sort(([a], [b]) => {
+      if (a === "Pending") return 1;
+      if (b === "Pending") return -1;
+      return a.localeCompare(b);
+    });
+
+    // Phase colors for sub-groups
+    const PHASE_COLORS = ["#6366f1","#22d3ee","#f59e0b","#a78bfa","#34d399","#f87171","#60a5fa","#fb923c"];
+
+    return entries.map(([dateKey, groupNodes]) => {
+      // Sub-group by phase within each date
+      const phaseMap = new Map<string, Node3D[]>();
+      groupNodes.forEach((n) => {
+        const props = (n.data.properties ?? {}) as Record<string, unknown>;
+        const phaseNum = props.phase as number | undefined;
+        const phaseName = props.phase_name as string | undefined;
+        const phaseKey = phaseNum ? String(phaseNum) : "other";
+        const phaseLabel = phaseName ? `Phase ${phaseNum} · ${phaseName}` : phaseNum ? `Phase ${phaseNum}` : "Other";
+        if (!phaseMap.has(phaseKey)) phaseMap.set(phaseKey, []);
+        phaseMap.get(phaseKey)!.push(n);
+        // store label alongside (hack: prefix key with label)
+        (phaseMap as Map<string, Node3D[] & { _label?: string }>).get(phaseKey)!;
+      });
+
+      // Sort phases numerically
+      const phaseEntries = Array.from(phaseMap.entries()).sort(([a], [b]) => {
+        if (a === "other") return 1;
+        if (b === "other") return -1;
+        return parseInt(a) - parseInt(b);
+      });
+
+      const phases: PhaseGroup[] = phaseEntries.map(([phaseKey, phaseNodes], pi) => {
+        const firstNode = phaseNodes[0];
+        const props = (firstNode.data.properties ?? {}) as Record<string, unknown>;
+        const phaseNum = props.phase as number | undefined;
+        const phaseName = props.phase_name as string | undefined;
+        return {
+          phaseKey,
+          phaseLabel: phaseName ? `Phase ${phaseNum} · ${phaseName}` : phaseNum ? `Phase ${phaseNum}` : "Other",
+          color: PHASE_COLORS[pi % PHASE_COLORS.length],
+          nodes: phaseNodes.sort((a, b) => (a.data.priority ?? 99) - (b.data.priority ?? 99)),
+        };
+      });
+
+      return {
+        dateKey,
+        dateLabel: dateKey === "Pending" ? "Pending / Not started" : formatDate(dateKey + "T00:00:00Z"),
+        phases,
+      };
+    });
+  }, [filtered]);
+
+  const completedCount = tickets.filter((n) => n.data.status === "completed").length;
+  const total = tickets.length;
+
+  return (
+    <div
+      style={{
+        width: "100%", height: "100%", overflowY: "auto", overflowX: "hidden",
+        background: "#080b14", position: "relative",
+      }}
+    >
+      {/* Header */}
+      <div style={{
+        position: "sticky", top: 0, zIndex: 10,
+        background: "rgba(8,11,20,0.95)", backdropFilter: "blur(8px)",
+        borderBottom: "1px solid rgba(255,255,255,0.06)",
+        padding: "12px 24px", display: "flex", alignItems: "center", gap: 16,
+      }}>
+        <span style={{ fontFamily: "monospace", fontSize: 11, color: "#22c55e", fontWeight: 700 }}>
+          {completedCount}/{total} DONE
+        </span>
+        {/* Progress bar */}
+        <div style={{ flex: 1, height: 3, background: "rgba(255,255,255,0.06)", borderRadius: 2, maxWidth: 200 }}>
+          <div style={{
+            height: "100%", borderRadius: 2, background: "#22c55e",
+            width: `${total > 0 ? (completedCount / total) * 100 : 0}%`,
+            transition: "width 0.5s",
+          }} />
+        </div>
+        {/* Filter pills */}
+        <div style={{ display: "flex", gap: 6, marginLeft: "auto" }}>
+          {(["all", "completed", "pending"] as const).map((f) => (
+            <button key={f} onClick={() => setFilter(f)} style={{
+              fontFamily: "monospace", fontSize: 9, padding: "3px 10px", borderRadius: 20,
+              border: `1px solid ${filter === f ? "rgba(129,140,248,0.6)" : "rgba(255,255,255,0.08)"}`,
+              background: filter === f ? "rgba(129,140,248,0.12)" : "transparent",
+              color: filter === f ? "#a5b4fc" : "#475569", cursor: "pointer",
+              textTransform: "uppercase", letterSpacing: "0.1em",
+            }}>{f}</button>
+          ))}
+        </div>
+      </div>
+
+      {/* Timeline */}
+      <div style={{ padding: "24px 24px 24px 40px", position: "relative" }}>
+        {/* Vertical line */}
+        <div style={{
+          position: "absolute", left: 52, top: 0, bottom: 0,
+          width: 1, background: "rgba(255,255,255,0.06)",
+        }} />
+
+        {groups.map((group, gi) => (
+          <div key={group.dateKey} style={{ marginBottom: 40, position: "relative" }}>
+            {/* Date marker */}
+            <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 16, position: "relative" }}>
+              {/* Dot on timeline */}
+              <div style={{
+                position: "absolute", left: -28,
+                width: 10, height: 10, borderRadius: "50%",
+                background: group.dateKey === "Pending" ? "#334155" : "#22c55e",
+                border: `2px solid ${group.dateKey === "Pending" ? "#475569" : "#4ade80"}`,
+                boxShadow: group.dateKey !== "Pending" ? "0 0 8px #22c55e88" : "none",
+              }} />
+              <span style={{
+                fontFamily: "monospace", fontSize: 11, color: "#94a3b8",
+                fontWeight: 600, letterSpacing: "0.05em",
+              }}>
+                {group.dateLabel}
+              </span>
+              <span style={{ fontFamily: "monospace", fontSize: 9, color: "#334155" }}>
+                — {group.phases.reduce((sum, p) => sum + p.nodes.length, 0)} ticket{group.phases.reduce((sum, p) => sum + p.nodes.length, 0) !== 1 ? "s" : ""}
+              </span>
+            </div>
+
+            {/* Phase sub-groups */}
+            {group.phases.map((phaseGroup) => (
+              <div key={phaseGroup.phaseKey} style={{ marginBottom: 16 }}>
+                {/* Phase label */}
+                <div style={{
+                  fontFamily: "monospace", fontSize: 9, color: phaseGroup.color,
+                  textTransform: "uppercase", letterSpacing: "0.1em", marginBottom: 8,
+                  display: "flex", alignItems: "center", gap: 6,
+                }}>
+                  <div style={{ width: 8, height: 2, background: phaseGroup.color, borderRadius: 1 }} />
+                  {phaseGroup.phaseLabel}
+                  <span style={{ color: "#334155" }}>({phaseGroup.nodes.length})</span>
+                </div>
+
+                {/* Ticket grid */}
+                <div style={{
+                  display: "grid",
+                  gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))",
+                  gap: 8,
+                }}>
+                  {phaseGroup.nodes.map((node) => {
+                const isPinned = node.id === pinnedNodeId;
+                const color = STATUS_COLOR[node.data.status] ?? "#475569";
+                const icon = STATUS_ICON[node.data.status] ?? "🔒";
+                const phaseName = getPhaseName(node);
+                const props = (node.data.properties ?? {}) as Record<string, unknown>;
+                const itemId = props.item_id as string | undefined;
+                const commitHash = props.commit_hash as string | undefined;
+
+                return (
+                  <div
+                    key={node.id}
+                    onClick={() => {
+                      if (!isPinned) sfxPanelOpen();
+                      setPinnedNode(isPinned ? null : node.id);
+                    }}
+                    style={{
+                      background: isPinned ? "rgba(99,102,241,0.12)" : "rgba(255,255,255,0.02)",
+                      borderTop: `1px solid ${isPinned ? color : "rgba(255,255,255,0.07)"}`,
+                      borderRight: `1px solid ${isPinned ? color : "rgba(255,255,255,0.07)"}`,
+                      borderBottom: `1px solid ${isPinned ? color : "rgba(255,255,255,0.07)"}`,
+                      borderLeft: `1px solid ${isPinned ? color : "rgba(255,255,255,0.07)"}`,
+                      borderRadius: 4, padding: "10px 10px 8px",
+                      cursor: "pointer", transition: "all 0.12s",
+                      boxShadow: isPinned ? `0 0 12px ${color}33` : "none",
+                    }}
+                    onMouseEnter={(e) => {
+                      if (!isPinned) (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.04)";
+                    }}
+                    onMouseLeave={(e) => {
+                      if (!isPinned) (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.02)";
+                    }}
+                  >
+                    {/* ID */}
+                    <div style={{ fontFamily: "monospace", fontSize: 9, color: "#475569", marginBottom: 3 }}>
+                      {itemId ?? node.id.toUpperCase()}
+                    </div>
+                    {/* Title */}
+                    <div style={{
+                      fontFamily: "monospace", fontSize: 10, fontWeight: 600,
+                      color: "#cbd5e1", lineHeight: 1.4, marginBottom: 6,
+                      display: "-webkit-box", WebkitLineClamp: 2,
+                      WebkitBoxOrient: "vertical", overflow: "hidden",
+                    }}>
+                      {node.data.label.replace(/^ITEM-\d+:\s*/, "")}
+                    </div>
+
+                    {/* Status row */}
+                    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+                      <span style={{ fontSize: 10, color: color, fontFamily: "monospace", fontWeight: 600 }}>
+                        {icon} {node.data.status.replace("_", " ").toUpperCase()}
+                      </span>
+                      {commitHash && (
+                        <span style={{ fontFamily: "monospace", fontSize: 8, color: "#334155" }}>
+                          {commitHash.slice(0, 6)}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        ))}
+
+        {groups.length === 0 && (
+          <div style={{ fontFamily: "monospace", fontSize: 12, color: "#334155", textAlign: "center", marginTop: 80 }}>
+            No tickets match the current filter.
+          </div>
+        )}
+      </div>
+
+      {/* Pinned node detail panel */}
+      {pinnedNode && (
+        <NodeDetailPanel
+          key={pinnedNode.id}
+          node={pinnedNode}
+          pinned
+          onClose={() => setPinnedNode(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useState } from "react";
 import { useChatStore } from "@/lib/store/chat-store";
 import { useTreeStore } from "@/lib/store/tree-store";
 import { createClient } from "@/lib/supabase/client";
@@ -21,9 +21,11 @@ interface ChatPanelProps {
 export function ChatPanel({ treeId, onCollapse }: ChatPanelProps) {
   const {
     messages, isStreaming, streamingContent, suggestions,
-    addMessage, setMessages, setStreaming, appendStreamContent, resetStreamContent,
+    addMessage, setMessages, clearMessages, setStreaming, appendStreamContent, resetStreamContent,
     setSuggestions, clearSuggestions,
   } = useChatStore();
+
+  const [confirmClear, setConfirmClear] = useState(false);
 
   const { pendingChanges, addPendingChange, resolveAllPending, addNode, removeNode, updateNode, updateNodeContent, nodes, addEdge, removeEdge, pushHistory } = useTreeStore();
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -193,8 +195,27 @@ export function ChatPanel({ treeId, onCollapse }: ChatPanelProps) {
     });
   }
 
+  async function handleClear() {
+    if (!confirmClear) {
+      setConfirmClear(true);
+      return;
+    }
+    setConfirmClear(false);
+    await supabase.from("chat_messages").delete().eq("tree_id", treeId);
+    clearMessages();
+    toast.success("Conversation cleared");
+  }
+
   async function sendMessage(content: string) {
     clearSuggestions();
+
+    // Intercept /clear command
+    if (content.trim().toLowerCase() === "/clear") {
+      await supabase.from("chat_messages").delete().eq("tree_id", treeId);
+      clearMessages();
+      toast.success("Conversation cleared");
+      return;
+    }
 
     // Intercept /pm pause and /pm resume commands
     const trimmed = content.trim().toLowerCase();
@@ -499,17 +520,47 @@ export function ChatPanel({ treeId, onCollapse }: ChatPanelProps) {
     <div className="w-full glass border-l border-glass-border flex flex-col">
       <div className="p-3 border-b border-glass-border flex items-center justify-between shrink-0">
         <h2 className="font-mono font-semibold text-sm">AI Assistant</h2>
-        {onCollapse && (
-          <button
-            onClick={onCollapse}
-            className="text-slate-500 hover:text-white transition-colors p-1 rounded"
-            title="Collapse"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-            </svg>
-          </button>
-        )}
+        <div className="flex items-center gap-1">
+          {confirmClear ? (
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs text-slate-400">Clear all messages?</span>
+              <button
+                onClick={handleClear}
+                className="px-2 py-0.5 rounded bg-red-500/20 text-red-400 text-[10px] hover:bg-red-500/30 transition-colors"
+              >
+                Yes
+              </button>
+              <button
+                onClick={() => setConfirmClear(false)}
+                className="px-2 py-0.5 rounded bg-slate-700/50 text-slate-400 text-[10px] hover:bg-slate-700 transition-colors"
+              >
+                No
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={handleClear}
+              className="text-slate-500 hover:text-red-400 transition-colors p-1 rounded"
+              title="Clear conversation"
+              disabled={messages.length === 0}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+            </button>
+          )}
+          {onCollapse && (
+            <button
+              onClick={onCollapse}
+              className="text-slate-500 hover:text-white transition-colors p-1 rounded"
+              title="Collapse"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+          )}
+        </div>
       </div>
 
       <div className="flex-1 overflow-y-auto p-3 space-y-3">

--- a/src/lib/store/chat-store.ts
+++ b/src/lib/store/chat-store.ts
@@ -9,6 +9,7 @@ interface ChatState {
 
   addMessage: (message: ChatMessage) => void;
   setMessages: (messages: ChatMessage[]) => void;
+  clearMessages: () => void;
   setStreaming: (streaming: boolean) => void;
   appendStreamContent: (text: string) => void;
   resetStreamContent: () => void;
@@ -26,6 +27,8 @@ export const useChatStore = create<ChatState>((set) => ({
     set((state) => ({ messages: [...state.messages, message] })),
 
   setMessages: (messages) => set({ messages }),
+
+  clearMessages: () => set({ messages: [], suggestions: [] }),
 
   setStreaming: (isStreaming) => set({ isStreaming }),
 


### PR DESCRIPTION
## ITEM-148: AI assistant — clear conversation history command

### What was built
Added a clear conversation history feature to the AI chat panel. Users can now delete all chat messages for the current tree via a trash icon button in the header, or by typing the /clear slash command in the chat input.

### Key technical decisions
- Two-step confirmation flow for the trash button: click once to show inline 'Clear all messages? Yes / No', then confirm. No modal needed, keeping the UI lightweight.
- The /clear slash command is intercepted early in sendMessage before the message is added to history, so no ghost user message appears.
- Both paths DELETE from chat_messages in Supabase (filtered by tree_id) and call clearMessages() on the Zustand store to sync in-memory state immediately.
- Added clearMessages to useChatStore as a new action that resets both messages and suggestions arrays in one call.
- Trash button is disabled when there are no messages to prevent unnecessary DB calls.

### Files changed
- src/lib/store/chat-store.ts: added clearMessages() action to interface and implementation; resets messages and suggestions in a single set call
- src/components/chat/ChatPanel.tsx: added useState import; destructured clearMessages from store; added handleClear() async function with two-step confirm logic; added /clear slash command intercept in sendMessage; updated header to flex row with trash button + inline confirmation UI + collapse button

### How to verify
1. Open any skill tree and send a few messages in the AI chat panel
2. Click the trash icon in the chat header - inline confirmation appears
3. Click Yes - messages disappear, toast shows 'Conversation cleared'
4. Click No - confirmation dismisses, messages remain
5. Type /clear in the chat input - same result without confirmation
6. Refresh the page - messages stay gone (DB was cleared)
