### PR TITLE
ITEM-151: Tree switcher — instant switch between trees without page reload

### DIFF
--- a/src/app/(app)/tree/[id]/page.tsx
+++ b/src/app/(app)/tree/[id]/page.tsx
@@ -11,6 +11,8 @@ import { KanbanView } from "@/components/canvas/KanbanView";
 import { CanvasErrorBoundary } from "@/components/ui/CanvasErrorBoundary";
 import { ChatPanel } from "@/components/chat/ChatPanel";
 import { ViewSwitcher } from "@/components/canvas/ViewSwitcher";
+import { TreeSwitcher } from "@/components/canvas/TreeSwitcher";
+import { TreeCommandPalette } from "@/components/canvas/TreeCommandPalette";
 import type { SkillNode, SkillEdge } from "@/types/skill-tree";
 import { toast } from "sonner";
 
@@ -196,6 +198,7 @@ export default function TreePage({ params }: { params: Promise<{ id: string }> }
 
   return (
     <div className="h-screen flex flex-col">
+      <TreeCommandPalette treeId={id} />
       <header className="glass border-b border-glass-border px-4 py-2 flex items-center justify-between shrink-0">
         <div className="flex items-center gap-3">
           <a
@@ -204,7 +207,7 @@ export default function TreePage({ params }: { params: Promise<{ id: string }> }
           >
             &larr; Back
           </a>
-          <h1 className="font-mono font-semibold text-lg truncate max-w-[140px] sm:max-w-none">{treeName}</h1>
+          <TreeSwitcher treeId={id} treeName={treeName} />
         </div>
         <div className="flex items-center gap-2">
           {/* View mode switcher */}

--- a/src/components/canvas/TreeCommandPalette.tsx
+++ b/src/components/canvas/TreeCommandPalette.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+
+interface Tree {
+  id: string;
+  name: string;
+}
+
+interface TreeCommandPaletteProps {
+  treeId: string;
+}
+
+export function TreeCommandPalette({ treeId }: TreeCommandPaletteProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [trees, setTrees] = useState<Tree[]>([]);
+  const [filter, setFilter] = useState("");
+  const [selected, setSelected] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const supabase = createClient();
+
+  // Global Cmd/Ctrl+K listener
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        setOpen((v) => !v);
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  // Fetch trees once
+  useEffect(() => {
+    supabase
+      .from("skill_trees")
+      .select("id, name")
+      .order("name")
+      .then(({ data }) => setTrees(data ?? []));
+  }, []);
+
+  // Reset state on open
+  useEffect(() => {
+    if (open) {
+      setFilter("");
+      setSelected(0);
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [open]);
+
+  const filtered = trees.filter((t) =>
+    t.name.toLowerCase().includes(filter.toLowerCase())
+  );
+
+  // Keep selected in bounds when filter changes
+  useEffect(() => {
+    setSelected(0);
+  }, [filter]);
+
+  function switchTree(id: string) {
+    setOpen(false);
+    if (id !== treeId) router.replace(`/tree/${id}`);
+  }
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") {
+      setOpen(false);
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelected((s) => Math.min(s + 1, filtered.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelected((s) => Math.max(s - 1, 0));
+    } else if (e.key === "Enter") {
+      if (filtered[selected]) switchTree(filtered[selected].id);
+    }
+  }
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-24 px-4"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) setOpen(false);
+      }}
+      style={{ background: "rgba(0,0,0,0.6)" }}
+    >
+      <div className="w-full max-w-md glass border border-glass-border rounded-lg shadow-2xl overflow-hidden">
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-glass-border">
+          <svg className="w-4 h-4 text-slate-400 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M17 11A6 6 0 105 11a6 6 0 0012 0z" />
+          </svg>
+          <input
+            ref={inputRef}
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder="Switch tree…"
+            className="flex-1 bg-transparent text-sm font-mono text-white placeholder-slate-500 outline-none"
+          />
+          <kbd className="text-[10px] font-mono text-slate-500 border border-slate-700 rounded px-1 py-0.5">ESC</kbd>
+        </div>
+
+        <ul className="max-h-72 overflow-y-auto py-1">
+          {filtered.length === 0 ? (
+            <li className="px-4 py-3 text-sm text-slate-500 font-mono">No trees found</li>
+          ) : (
+            filtered.map((t, i) => (
+              <li key={t.id}>
+                <button
+                  onClick={() => switchTree(t.id)}
+                  onMouseEnter={() => setSelected(i)}
+                  className={`w-full text-left px-4 py-2.5 text-sm font-mono flex items-center gap-2 transition-colors ${
+                    i === selected ? "bg-white/10 text-white" : "text-slate-300 hover:bg-white/5"
+                  }`}
+                >
+                  {t.id === treeId ? (
+                    <svg className="w-3.5 h-3.5 shrink-0 text-accent-blue" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                    </svg>
+                  ) : (
+                    <span className="w-3.5 h-3.5 shrink-0" />
+                  )}
+                  <span className="truncate">{t.name}</span>
+                </button>
+              </li>
+            ))
+          )}
+        </ul>
+
+        <div className="px-4 py-2 border-t border-glass-border flex items-center gap-3 text-[10px] text-slate-500 font-mono">
+          <span><kbd className="border border-slate-700 rounded px-1">↑↓</kbd> navigate</span>
+          <span><kbd className="border border-slate-700 rounded px-1">↵</kbd> select</span>
+          <span><kbd className="border border-slate-700 rounded px-1">esc</kbd> close</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/canvas/TreeSwitcher.tsx
+++ b/src/components/canvas/TreeSwitcher.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+
+interface Tree {
+  id: string;
+  name: string;
+}
+
+interface TreeSwitcherProps {
+  treeId: string;
+  treeName: string;
+}
+
+export function TreeSwitcher({ treeId, treeName }: TreeSwitcherProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [trees, setTrees] = useState<Tree[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [filter, setFilter] = useState("");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const supabase = createClient();
+
+  useEffect(() => {
+    setLoading(true);
+    supabase
+      .from("skill_trees")
+      .select("id, name")
+      .order("name")
+      .then(({ data }) => {
+        setTrees(data ?? []);
+        setLoading(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      setFilter("");
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    function onClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) document.addEventListener("mousedown", onClickOutside);
+    return () => document.removeEventListener("mousedown", onClickOutside);
+  }, [open]);
+
+  function switchTree(id: string) {
+    setOpen(false);
+    if (id !== treeId) router.replace(`/tree/${id}`);
+  }
+
+  const filtered = trees.filter((t) =>
+    t.name.toLowerCase().includes(filter.toLowerCase())
+  );
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-1.5 font-mono font-semibold text-lg truncate max-w-[140px] sm:max-w-xs hover:text-white transition-colors"
+        title="Switch tree"
+      >
+        <span className="truncate">{treeName}</span>
+        {loading ? (
+          <svg className="w-3.5 h-3.5 shrink-0 animate-spin text-slate-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+          </svg>
+        ) : (
+          <svg
+            className={`w-3.5 h-3.5 shrink-0 text-slate-400 transition-transform ${open ? "rotate-180" : ""}`}
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute top-full left-0 mt-1 w-64 glass border border-glass-border rounded shadow-xl z-50 overflow-hidden">
+          <div className="p-2 border-b border-glass-border">
+            <input
+              ref={inputRef}
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Filter trees…"
+              className="w-full bg-transparent text-sm font-mono text-white placeholder-slate-500 outline-none"
+            />
+          </div>
+          <ul className="max-h-60 overflow-y-auto">
+            {filtered.length === 0 ? (
+              <li className="px-3 py-2 text-xs text-slate-500 font-mono">No trees found</li>
+            ) : (
+              filtered.map((t) => (
+                <li key={t.id}>
+                  <button
+                    onClick={() => switchTree(t.id)}
+                    className={`w-full text-left px-3 py-2 text-sm font-mono truncate hover:bg-white/5 transition-colors ${
+                      t.id === treeId ? "text-accent-blue" : "text-slate-300"
+                    }`}
+                  >
+                    {t.id === treeId && <span className="mr-1.5">✓</span>}
+                    {t.name}
+                  </button>
+                </li>
+              ))
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## ITEM-151: Tree switcher

Adds instant tree switching within the skill tree view — no page navigation required.

### What was built

**TreeSwitcher** — a dropdown component in the header bar (next to the tree name) that lets users switch between their skill trees instantly. It fetches all trees for the current user on mount, displays the current tree name with a chevron, and opens a searchable dropdown on click. Selecting a tree calls `router.replace` to update the URL, which triggers the existing `useEffect([id])` in the page to reload data automatically.

**TreeCommandPalette** — a Cmd/Ctrl+K command palette modal. Mounts globally on the tree page, listens for the keyboard shortcut, and opens a full-screen overlay with a search input and arrow-key navigation. Enter selects a tree, Escape or backdrop click closes it.

### Key technical decisions
- Used `router.replace` (not `push`) so back-button behavior is clean
- Leveraged the existing `useEffect([id])` in `page.tsx` to handle data reload — no duplicated fetch logic
- RLS on `skill_trees` handles user scoping — no explicit user_id filter needed
- Both components share the same Supabase query and glass/font-mono styling

### Files changed
- `src/components/canvas/TreeSwitcher.tsx` — new: header dropdown switcher with search
- `src/components/canvas/TreeCommandPalette.tsx` — new: Cmd/Ctrl+K command palette
- `src/app/(app)/tree/[id]/page.tsx` — updated: replaced h1 with TreeSwitcher, mounted TreeCommandPalette

### How to verify
1. Open any tree (`/tree/[id]`)
2. Click the tree name in the header — dropdown appears with all your trees
3. Type to filter, click a tree — URL updates and galaxy reloads without full page navigation
4. Press Cmd/Ctrl+K — command palette opens, type to search, Enter or click to switch