### PR TITLE
ITEM-153: Realtime tree sync — board and timeline auto-update when agent completes tickets

### DIFF
--- a/src/components/canvas/TimelineView.tsx
+++ b/src/components/canvas/TimelineView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTreeStore } from "@/lib/store/tree-store";
 import { NodeDetailPanel } from "@/components/panel/NodeDetailPanel";
 import type { Node3D } from "@/lib/store/tree-store";
@@ -70,6 +70,38 @@ export function TimelineView() {
   const pinnedNodeId = useTreeStore((s) => s.pinnedNodeId);
   const setPinnedNode = useTreeStore((s) => s.setPinnedNode);
   const [filter, setFilter] = useState<"all" | "completed" | "pending">("all");
+
+  // Flash animation: track recently updated node IDs
+  const [flashNodeIds, setFlashNodeIds] = useState<Set<string>>(new Set());
+  const prevNodesRef = useRef<Map<string, string>>(new Map());
+
+  // Detect node status changes and trigger flash animation
+  useEffect(() => {
+    const prev = prevNodesRef.current;
+    const updated: string[] = [];
+    for (const node of nodes) {
+      const prevStatus = prev.get(node.id);
+      if (prevStatus !== undefined && prevStatus !== node.data.status) {
+        updated.push(node.id);
+      }
+      prev.set(node.id, node.data.status ?? "");
+    }
+    if (updated.length > 0) {
+      setFlashNodeIds((cur) => {
+        const next = new Set(cur);
+        for (const id of updated) next.add(id);
+        return next;
+      });
+      const timer = setTimeout(() => {
+        setFlashNodeIds((cur) => {
+          const next = new Set(cur);
+          for (const id of updated) next.delete(id);
+          return next;
+        });
+      }, 1200);
+      return () => clearTimeout(timer);
+    }
+  }, [nodes]);
 
   const pinnedNode = useMemo(
     () => nodes.find((n) => n.id === pinnedNodeId) ?? null,
@@ -247,6 +279,7 @@ export function TimelineView() {
                 }}>
                   {phaseGroup.nodes.map((node) => {
                 const isPinned = node.id === pinnedNodeId;
+                const isFlashing = flashNodeIds.has(node.id);
                 const color = STATUS_COLOR[node.data.status] ?? "#475569";
                 const icon = STATUS_ICON[node.data.status] ?? "🔒";
                 const phaseName = getPhaseName(node);
@@ -262,20 +295,20 @@ export function TimelineView() {
                       setPinnedNode(isPinned ? null : node.id);
                     }}
                     style={{
-                      background: isPinned ? "rgba(99,102,241,0.12)" : "rgba(255,255,255,0.02)",
-                      borderTop: `1px solid ${isPinned ? color : "rgba(255,255,255,0.07)"}`,
-                      borderRight: `1px solid ${isPinned ? color : "rgba(255,255,255,0.07)"}`,
-                      borderBottom: `1px solid ${isPinned ? color : "rgba(255,255,255,0.07)"}`,
-                      borderLeft: `1px solid ${isPinned ? color : "rgba(255,255,255,0.07)"}`,
+                      background: isFlashing ? `${color}1a` : isPinned ? "rgba(99,102,241,0.12)" : "rgba(255,255,255,0.02)",
+                      borderTop: `1px solid ${isPinned || isFlashing ? color : "rgba(255,255,255,0.07)"}`,
+                      borderRight: `1px solid ${isPinned || isFlashing ? color : "rgba(255,255,255,0.07)"}`,
+                      borderBottom: `1px solid ${isPinned || isFlashing ? color : "rgba(255,255,255,0.07)"}`,
+                      borderLeft: `1px solid ${isPinned || isFlashing ? color : "rgba(255,255,255,0.07)"}`,
                       borderRadius: 4, padding: "10px 10px 8px",
-                      cursor: "pointer", transition: "all 0.12s",
-                      boxShadow: isPinned ? `0 0 12px ${color}33` : "none",
+                      cursor: "pointer", transition: isFlashing ? "all 0.3s" : "all 0.12s",
+                      boxShadow: isFlashing ? `0 0 10px ${color}55` : isPinned ? `0 0 12px ${color}33` : "none",
                     }}
                     onMouseEnter={(e) => {
-                      if (!isPinned) (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.04)";
+                      if (!isPinned && !isFlashing) (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.04)";
                     }}
                     onMouseLeave={(e) => {
-                      if (!isPinned) (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.02)";
+                      if (!isPinned && !isFlashing) (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.02)";
                     }}
                   >
                     {/* ID */}


### PR DESCRIPTION
## What was built

This ticket adds realtime auto-update support to the Timeline view in the SkillForge board. The Board/Kanban view already had full realtime sync with flash animations; the Timeline view was reading from the store reactively but lacked the subtle pulse/flash effect when a node was updated by a coding agent completing a ticket.

## Key technical decisions

- **No new subscription needed**: The page-level Supabase Realtime subscription in `page.tsx` already calls `updateNode` in the Zustand store on every `UPDATE` event. Since `TimelineView` reads nodes from the store via `useTreeStore`, it already re-renders automatically. The only missing piece was visual feedback (flash animation) on card update.
- **Status-diff detection**: Rather than adding a second Supabase subscription, the component tracks previous node statuses in a `useRef` map and detects changes via a `useEffect` on the `nodes` array. When a status change is detected, the node ID is added to a `flashNodeIds` set for 1200ms, matching the Board view's flash duration.
- **Visual styling**: Flashing cards get a color-tinted background (`color + '1a'` alpha), colored borders, and a glow box-shadow using the status color — consistent with how the KanbanView does it.

## Files changed

- `src/components/canvas/TimelineView.tsx`:
  - Added `useEffect` and `useRef` imports
  - Added `flashNodeIds` state (Set of recently-updated node IDs)
  - Added `prevNodesRef` to track previous node statuses
  - Added `useEffect` that diffs nodes on every render and triggers flash for changed statuses
  - Updated ticket card `div` styles to apply flash background, border, and glow when `isFlashing` is true

## How to verify

1. Open the Timeline view on any active tree
2. From another tab or via the PM bot, mark a ticket as completed
3. The updated ticket card should briefly flash with a colored glow (border + background tint) matching its new status color, then fade back — no page refresh needed