### PR TITLE
Add Claude project settings and GitHub Actions CI

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,52 @@
+# SkillForge — Project Rules
+
+## Git Workflow
+
+- Never commit directly to `master`.
+- For every change: create a new branch, commit, push, create a PR, and merge it.
+- After merging, always return the PR URL to the user.
+- This ensures all changes are tracked via PR history.
+
+## Project Overview
+
+- AI-powered galaxy skill tree builder with 3D visualization.
+- Next.js 15 (App Router) + React 19 + TypeScript.
+- Supabase for auth + PostgreSQL database.
+- React Three Fiber for 3D rendering, Zustand for state management.
+- Claude API with tool use + SSE streaming for AI features.
+- Entry point: `npm run dev`
+
+## Architecture
+
+- **Solar system metaphor**: Stellars = stars, Planets = skills, Satellites = sub-skills.
+- Hierarchy via `parent_id` + `role` — no edges.
+- 3D layout computed at runtime by `layoutGalaxy()`, not stored in DB.
+- AI proposes changes via tool calls → PendingChange cards → user accepts/rejects → persisted.
+
+## Key Paths
+
+- `src/lib/ai/` — Claude prompts, tools, streaming
+- `src/lib/store/tree-store.ts` — Zustand store + orbital layout
+- `src/components/canvas/` — 3D rendering (planets, skill nodes)
+- `src/app/api/chat/route.ts` — Claude streaming SSE endpoint
+
+## Conventions
+
+- Node.js 18 — no packages requiring Node 20+.
+- Tailwind CSS v3 (not v4).
+- `frameloop="always"` for Three.js canvas.
+- Do NOT run `next build` to validate — user tests via `npm run dev`.
+
+## Database
+
+- Tables: `skill_trees`, `skill_nodes`, `skill_edges` (unused), `chat_messages`
+- RLS on all tables, scoped to `auth.uid()`
+- Composite PK on skill_nodes: `(id, tree_id)`
+
+## Environment
+
+Env vars in `.env.local`:
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `ANTHROPIC_API_KEY`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run lint
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - run: npm ci
+
+      - run: npx tsc --noEmit


### PR DESCRIPTION
## Summary
- Add `.claude/CLAUDE.md` with project rules: git workflow (branch → PR → merge), architecture overview, conventions, and key paths
- Add `.github/workflows/ci.yml` with three CI jobs: lint, build (with secrets), and typecheck
- Establishes consistent team workflow and automated quality checks on every PR

## Test plan
- [ ] Verify CI workflow triggers on PR and push to master
- [ ] Confirm lint, build, and typecheck jobs pass
- [ ] Set required GitHub secrets (NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY, ANTHROPIC_API_KEY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)