### PR TITLE
Add settings page with password change

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -215,12 +215,20 @@ export default function DashboardPage() {
         <h1 className="text-3xl font-bold font-mono bg-gradient-to-r from-accent-blue to-accent-purple bg-clip-text text-transparent">
           SkillForge
         </h1>
-        <button
-          onClick={handleSignOut}
-          className="text-sm text-slate-500 hover:text-slate-300 transition-colors"
-        >
-          Sign Out
-        </button>
+        <div className="flex items-center gap-4">
+          <button
+            onClick={() => router.push("/settings")}
+            className="text-sm text-slate-500 hover:text-slate-300 transition-colors"
+          >
+            Settings
+          </button>
+          <button
+            onClick={handleSignOut}
+            className="text-sm text-slate-500 hover:text-slate-300 transition-colors"
+          >
+            Sign Out
+          </button>
+        </div>
       </div>
 
       <div className="glass rounded-xl p-4 mb-6">

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+export default function SettingsPage() {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+  const supabase = createClient();
+
+  async function handleUpdatePassword(e: React.FormEvent) {
+    e.preventDefault();
+
+    if (newPassword.length < 6) {
+      toast.error("New password must be at least 6 characters");
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      toast.error("Passwords do not match");
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      // Verify current password by re-authenticating
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user?.email) {
+        toast.error("Unable to get current user");
+        setLoading(false);
+        return;
+      }
+
+      const { error: signInError } = await supabase.auth.signInWithPassword({
+        email: user.email,
+        password: currentPassword,
+      });
+
+      if (signInError) {
+        toast.error("Current password is incorrect");
+        setLoading(false);
+        return;
+      }
+
+      // Update password
+      const { error } = await supabase.auth.updateUser({
+        password: newPassword,
+      });
+
+      if (error) {
+        toast.error(error.message);
+      } else {
+        toast.success("Password updated successfully");
+        setCurrentPassword("");
+        setNewPassword("");
+        setConfirmPassword("");
+      }
+    } catch {
+      toast.error("Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen p-6 max-w-4xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold font-mono">Settings</h1>
+        <button
+          onClick={() => router.push("/dashboard")}
+          className="text-sm text-slate-500 hover:text-slate-300 transition-colors"
+        >
+          Back to Dashboard
+        </button>
+      </div>
+
+      <div className="glass rounded-xl p-6">
+        <h2 className="text-lg font-semibold font-mono mb-4">Change Password</h2>
+
+        <form onSubmit={handleUpdatePassword} className="space-y-4 max-w-md">
+          <div>
+            <label className="block text-sm text-slate-400 mb-1">Current Password</label>
+            <input
+              type="password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              required
+              className="w-full px-3 py-2 rounded-lg bg-navy-900/50 border border-glass-border text-white placeholder-slate-500 focus:outline-none focus:border-accent-blue/50 transition-colors"
+              placeholder="Enter current password"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm text-slate-400 mb-1">New Password</label>
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              required
+              minLength={6}
+              className="w-full px-3 py-2 rounded-lg bg-navy-900/50 border border-glass-border text-white placeholder-slate-500 focus:outline-none focus:border-accent-blue/50 transition-colors"
+              placeholder="At least 6 characters"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm text-slate-400 mb-1">Confirm New Password</label>
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              required
+              minLength={6}
+              className="w-full px-3 py-2 rounded-lg bg-navy-900/50 border border-glass-border text-white placeholder-slate-500 focus:outline-none focus:border-accent-blue/50 transition-colors"
+              placeholder="Repeat new password"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="px-4 py-2 rounded-lg bg-accent-blue/20 text-accent-blue border border-accent-blue/30 hover:bg-accent-blue/30 transition-colors disabled:opacity-50 text-sm font-medium"
+          >
+            {loading ? "Updating..." : "Update Password"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/settings` page where users can update their password
- Verifies current password before allowing change (re-authenticates via Supabase)
- Validates min 6 chars and password confirmation match
- Added "Settings" link in dashboard header next to "Sign Out"

## Test plan
- [ ] Navigate to /settings from dashboard
- [ ] Try changing password with wrong current password (should show error)
- [ ] Try mismatched new/confirm passwords (should show error)
- [ ] Successfully change password and verify login with new password

🤖 Generated with [Claude Code](https://claude.com/claude-code)