### PR TITLE
Add flexible tree schema and view config types

### DIFF
--- a/src/types/skill-tree.ts
+++ b/src/types/skill-tree.ts
@@ -1,7 +1,55 @@
+// ── Property schema types (tree-level) ──────────────────────────────────────
+
+export type PropertyType = "select" | "multi_select" | "text" | "number" | "date" | "checkbox";
+
+export interface PropertyDef {
+  type: PropertyType;
+  options?: string[]; // for select / multi_select
+}
+
+export interface TreeSchema {
+  properties: Record<string, PropertyDef>;
+}
+
+// ── View config types ───────────────────────────────────────────────────────
+
+export type ViewType = "solar_system" | "kanban" | "gantt";
+
+export interface ViewConfig {
+  id: string;
+  name: string;
+  type: ViewType;
+  group_by?: string;   // property key for kanban grouping
+  date_field?: string;  // property key for gantt date
+  filters?: Array<{ property: string; operator: string; value: unknown }>;
+  sort_by?: string;
+  sort_dir?: "asc" | "desc";
+}
+
+// ── Default schema & views (mirrors legacy hardcoded behavior) ──────────────
+
+export const DEFAULT_SCHEMA: TreeSchema = {
+  properties: {
+    status: { type: "select", options: ["locked", "queued", "in_progress", "completed"] },
+    priority: { type: "number" },
+    due_date: { type: "date" },
+    assignee: { type: "text" },
+  },
+};
+
+export const DEFAULT_VIEW_CONFIGS: ViewConfig[] = [
+  { id: "solar",  name: "Solar System", type: "solar_system" },
+  { id: "kanban", name: "Board",        type: "kanban", group_by: "status" },
+  { id: "gantt",  name: "Timeline",     type: "gantt",  date_field: "due_date" },
+];
+
+// ── Legacy types (kept for backward compat during transition) ───────────────
+
 export type NodeStatus = "locked" | "queued" | "in_progress" | "completed";
 export type NodeRole = "stellar" | "planet" | "satellite";
-/** Canonical node type (replaces role). Seeded from role; user-extensible in future. */
-export type NodeType = NodeRole; // union may expand later
+export type NodeType = NodeRole;
+
+// ── Core data types ─────────────────────────────────────────────────────────
 
 export interface SkillTree {
   id: string;
@@ -9,6 +57,10 @@ export interface SkillTree {
   name: string;
   description: string | null;
   theme: string | null;
+  /** Property definitions for this tree. Falls back to DEFAULT_SCHEMA if empty. */
+  schema?: TreeSchema;
+  /** View configurations. Falls back to DEFAULT_VIEW_CONFIGS if empty. */
+  view_configs?: ViewConfig[];
   created_at: string;
   updated_at: string;
 }
@@ -18,30 +70,28 @@ export interface SkillNode {
   tree_id: string;
   label: string;
   description: string | null;
+  /** @deprecated Read from properties.status via getNodeProperty() instead. */
   status: NodeStatus;
-  /** Canonical column (added in migration 004). Prefer over role. */
+  /** Structural hierarchy for solar system view. */
   type: NodeType;
-  /** Legacy column kept for backward compatibility — mirrors type. */
+  /** @deprecated Use type instead. */
   role: NodeRole;
-  parent_id: string | null; // stellar has null, planet → stellar id, satellite → planet id
+  parent_id: string | null;
+  /** @deprecated Read from properties.priority via getNodeProperty() instead. */
   priority: number;
-  position_x: number; // unused for layout, kept for AI ordering hint
+  position_x: number;
   position_y: number;
   icon: string | null;
   metadata: Record<string, unknown> | null;
-  /** Flexible structured metadata (added in migration 004). Stored as jsonb in DB. */
+  /** Flexible properties — source of truth for all user-defined fields. */
   properties: Record<string, unknown>;
   content: import("./node-content").NodeContent;
-  /** ISO timestamp: when this node was created (ticket start for Gantt). */
   created_at?: string;
-  /** ISO timestamp: when this node's status last became 'completed' (ticket end for Gantt). */
   completed_at?: string | null;
 }
 
-/** Edge relationship type (added in migration 004). */
 export type EdgeType = "parent" | "depends_on" | "blocks" | "related" | "references";
 
-// Edges represent explicit relationships between nodes (supplementary to orbital hierarchy)
 export interface SkillEdge {
   id: string;
   tree_id: string;
@@ -51,4 +101,44 @@ export interface SkillEdge {
   type: EdgeType;
   weight: number;
   metadata: Record<string, unknown> | null;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Read a property from a node, with fallback to legacy columns. */
+export function getNodeProperty(node: SkillNode, key: string): unknown {
+  if (node.properties && key in node.properties) return node.properties[key];
+  // Legacy fallback
+  if (key === "status") return node.status;
+  if (key === "priority") return node.priority;
+  return undefined;
+}
+
+/** Write properties and sync legacy columns. Returns a partial update object. */
+export function buildNodeUpdate(
+  existing: SkillNode,
+  newProps: Record<string, unknown>
+): Partial<SkillNode> {
+  const merged = { ...existing.properties, ...newProps };
+  const update: Partial<SkillNode> = { properties: merged };
+  // Sync legacy columns
+  if ("status" in newProps) update.status = newProps.status as NodeStatus;
+  if ("priority" in newProps) update.priority = newProps.priority as number;
+  return update;
+}
+
+/** Resolve tree schema with defaults for missing fields. */
+export function resolveSchema(tree: SkillTree): TreeSchema {
+  const schema = tree.schema;
+  if (!schema || !schema.properties || Object.keys(schema.properties).length === 0) {
+    return DEFAULT_SCHEMA;
+  }
+  return schema;
+}
+
+/** Resolve view configs with defaults. */
+export function resolveViewConfigs(tree: SkillTree): ViewConfig[] {
+  const configs = tree.view_configs;
+  if (!configs || configs.length === 0) return DEFAULT_VIEW_CONFIGS;
+  return configs;
 }

--- a/supabase/migrations/009_flexible_schema.sql
+++ b/supabase/migrations/009_flexible_schema.sql
@@ -1,0 +1,45 @@
+-- Migration 009: Flexible tree schema and view configs
+-- Adds user-defined property schemas and view configurations per tree.
+-- Non-destructive: existing columns (status, priority, role) remain untouched.
+
+-- ── skill_trees: add schema + view_configs ──────────────────────────────────
+
+ALTER TABLE skill_trees
+  ADD COLUMN IF NOT EXISTS schema jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE skill_trees
+  ADD COLUMN IF NOT EXISTS view_configs jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+-- Backfill existing trees with a default schema mirroring the legacy columns
+UPDATE skill_trees SET schema = '{
+  "properties": {
+    "status": {
+      "type": "select",
+      "options": ["locked", "queued", "in_progress", "completed"]
+    },
+    "priority": {
+      "type": "number"
+    },
+    "due_date": {
+      "type": "date"
+    },
+    "assignee": {
+      "type": "text"
+    }
+  }
+}'::jsonb WHERE schema = '{}'::jsonb;
+
+-- Backfill view configs
+UPDATE skill_trees SET view_configs = '[
+  { "id": "solar",  "name": "Solar System", "type": "solar_system" },
+  { "id": "kanban", "name": "Board",        "type": "kanban", "group_by": "status" },
+  { "id": "gantt",  "name": "Timeline",     "type": "gantt",  "date_field": "due_date" }
+]'::jsonb WHERE view_configs = '[]'::jsonb;
+
+-- ── skill_nodes: backfill properties from legacy columns ────────────────────
+
+UPDATE skill_nodes
+SET properties = properties
+  || jsonb_build_object('status', status)
+  || jsonb_build_object('priority', priority)
+WHERE properties->>'status' IS NULL;


### PR DESCRIPTION
## Summary
- **Migration 009**: Adds `schema` and `view_configs` jsonb columns to `skill_trees`, backfills existing data
- **TypeScript types**: `TreeSchema`, `PropertyDef`, `ViewConfig` + helper functions (`getNodeProperty`, `buildNodeUpdate`, `resolveSchema`, `resolveViewConfigs`)
- Legacy columns (`status`, `priority`, `role`) kept — marked `@deprecated`

## What this enables
- Trees can define their own property schemas (select, multi_select, text, number, date, checkbox)
- Views can be configured per tree (kanban grouped by any select property, gantt by any date field)
- Foundation for Phases 3-10 of the Notion-like data model refactor

## Action required
Run migration 009 against Supabase:
```sql
-- Paste contents of supabase/migrations/009_flexible_schema.sql in Supabase SQL Editor
```

## Test plan
- [ ] Migration runs without errors on existing data
- [ ] App still works unchanged (types are backward compatible)
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)