### PR TITLE
Make node hierarchy configurable via tree schema

### DIFF
--- a/src/app/(app)/tree/[id]/page.tsx
+++ b/src/app/(app)/tree/[id]/page.tsx
@@ -107,9 +107,10 @@ export default function TreePage({ params }: { params: Promise<{ id: string }> }
       supabase.from("chat_messages").select("*").eq("tree_id", id).order("created_at", { ascending: true }),
     ]);
 
+    const schema = treeRes.data ? resolveSchema(treeRes.data) : undefined;
     if (treeRes.data) {
       setTreeName(treeRes.data.name);
-      setTreeSchema(resolveSchema(treeRes.data));
+      setTreeSchema(schema!);
       setViewConfigs(resolveViewConfigs(treeRes.data));
     }
 
@@ -117,7 +118,7 @@ export default function TreePage({ params }: { params: Promise<{ id: string }> }
       ...n,
       content: n.content ?? { blocks: [] },
     })) as SkillNode[];
-    setNodes(layoutGalaxy(activeNodes));
+    setNodes(layoutGalaxy(activeNodes, schema));
     setEdges((edgesRes.data ?? []) as SkillEdge[]);
     pushHistory();
 

--- a/src/app/share/[id]/page.tsx
+++ b/src/app/share/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useTreeStore, layoutGalaxy } from "@/lib/store/tree-store";
 import { ReadOnlyCanvas } from "@/components/canvas/ReadOnlyCanvas";
 import { CanvasErrorBoundary } from "@/components/ui/CanvasErrorBoundary";
 import type { SkillNode } from "@/types/skill-tree";
+import { resolveSchema } from "@/types/skill-tree";
 
 export default function SharePage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
@@ -27,12 +28,13 @@ export default function SharePage({ params }: { params: Promise<{ id: string }> 
     }
     const { tree, nodes } = await res.json();
     setTreeName(tree.name);
+    const schema = resolveSchema(tree);
 
     const mapped = (nodes as SkillNode[]).map((n) => ({
       ...n,
       content: n.content ?? { blocks: [] },
     }));
-    setNodes(layoutGalaxy(mapped));
+    setNodes(layoutGalaxy(mapped, schema));
     setLoading(false);
   }
 

--- a/src/components/canvas/KanbanView.tsx
+++ b/src/components/canvas/KanbanView.tsx
@@ -9,7 +9,7 @@ import { createClient } from "@/lib/supabase/client";
 import type { Node3D } from "@/lib/store/tree-store";
 import type { NodeStatus } from "@/types/skill-tree";
 import type { SkillNode, TreeSchema, ViewConfig } from "@/types/skill-tree";
-import { getNodeProperty, DEFAULT_SCHEMA } from "@/types/skill-tree";
+import { getNodeProperty, DEFAULT_SCHEMA, isCardType, getTypeLabel } from "@/types/skill-tree";
 
 // ── Dynamic column config builder ──────────────────────────────────────────
 
@@ -215,7 +215,7 @@ export function KanbanView({ schema, viewConfig }: { schema?: TreeSchema; viewCo
   // Derive available phases from stellar nodes
   const phases = useMemo(() => {
     return nodes
-      .filter((n) => (n.data.type ?? n.data.role) === "stellar")
+      .filter((n) => !isCardType(resolvedSchema, (n.data.type ?? n.data.role) as string))
       .map((n) => ({
         id: n.id,
         label: n.data.label,
@@ -240,7 +240,7 @@ export function KanbanView({ schema, viewConfig }: { schema?: TreeSchema; viewCo
     for (const node of seen.values()) {
       const nodeType = node.data.type ?? node.data.role;
       // Skip stellar (phase) nodes — only show planets (tickets)
-      if (nodeType === "stellar") continue;
+      if (!isCardType(resolvedSchema, nodeType)) continue;
       // Apply phase filter
       if (phaseFilter !== null) {
         const nodePhase = (node.data.properties as Record<string, unknown>)?.phase as number;

--- a/src/components/canvas/SkillNode3D.tsx
+++ b/src/components/canvas/SkillNode3D.tsx
@@ -7,6 +7,7 @@ import * as THREE from "three";
 import { useTreeStore, type Node3D } from "@/lib/store/tree-store";
 import { createClient } from "@/lib/supabase/client";
 import type { NodeStatus } from "@/types/skill-tree";
+import { getNodeRender } from "@/types/skill-tree";
 
 // ---------------------------------------------------------------------------
 // UnlockParticles — burst that plays once when a node goes locked→in_progress
@@ -149,9 +150,11 @@ function idSeed(id: string): number {
   return Math.abs(h);
 }
 
-function pickPlanetForRole(id: string, role: string) {
-  if (role === "stellar") return "sun";
-  if (role === "satellite") return "moon";
+function pickPlanetForRole(id: string, role: string, renderTier?: string) {
+  // Use render tier from schema if provided, otherwise infer from legacy role
+  const tier = renderTier ?? (role === "stellar" ? "star" : role === "satellite" ? "satellite" : "planet");
+  if (tier === "star") return "sun";
+  if (tier === "satellite") return "moon";
   return pickPlanetType(id);
 }
 
@@ -183,8 +186,14 @@ export const SkillNode3D = memo(function SkillNode3D({ node, parentMap, readOnly
   const pulseRingRef = useRef<THREE.Mesh>(null);
   const statusGlowRef = useRef<THREE.Mesh>(null);
 
+  const treeSchema = useTreeStore((s) => s.treeSchema);
   const seed = useMemo(() => idSeed(node.id), [node.id]);
-  const planetType = useMemo(() => pickPlanetForRole(node.id, node.data.type ?? node.data.role), [node.id, node.data.type, node.data.role]);
+  const effectiveRole = (node.data.type ?? node.data.role) as string;
+  const renderTier = useMemo(() => {
+    if (!treeSchema) return undefined;
+    return getNodeRender(treeSchema, effectiveRole) as string;
+  }, [treeSchema, effectiveRole]);
+  const planetType = useMemo(() => pickPlanetForRole(node.id, effectiveRole, renderTier), [node.id, effectiveRole, renderTier]);
   const config = useMemo(() => getPlanetConfig(planetType), [planetType]);
   const brightness = STATUS_BRIGHTNESS[node.data.status];
   const parent = node.data.parent_id ? parentMap.get(node.data.parent_id) : null;
@@ -204,8 +213,7 @@ export const SkillNode3D = memo(function SkillNode3D({ node, parentMap, readOnly
       const dy = camera.position.y - groupRef.current.position.y;
       const dz = camera.position.z - groupRef.current.position.z;
       const distSq = dx * dx + dy * dy + dz * dz;
-      const role = node.data.type ?? node.data.role;
-      const cullDistSq = role === "stellar" ? Infinity : role === "planet" ? 3600 : 900; // 60^2, 30^2
+      const cullDistSq = renderTier === "star" ? Infinity : renderTier === "satellite" ? 900 : 3600; // 60^2, 30^2
       const shouldBeVisible = distSq <= cullDistSq;
       if (groupRef.current.visible !== shouldBeVisible) {
         groupRef.current.visible = shouldBeVisible;

--- a/src/components/canvas/SkillTreeCanvas.tsx
+++ b/src/components/canvas/SkillTreeCanvas.tsx
@@ -5,6 +5,7 @@ import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import { OrbitControls, Stars, OrthographicCamera } from "@react-three/drei";
 import * as THREE from "three";
 import { useTreeStore, type Node3D } from "@/lib/store/tree-store";
+import { getNodeRender } from "@/types/skill-tree";
 import { SkillNode3D, worldPositions } from "./SkillNode3D";
 import { OrbitalRing } from "./OrbitalRing";
 import { EdgeRenderer } from "./EdgeRenderer";
@@ -227,8 +228,15 @@ function StaggeredNodes({ nodes, nodeMap, onProgress }: {
   nodeMap: Map<string, Node3D>;
   onProgress: (loaded: number, total: number) => void;
 }) {
-  const stellars = useMemo(() => nodes.filter((n) => (n.data.type ?? n.data.role) === "stellar"), [nodes]);
-  const planets = useMemo(() => nodes.filter((n) => (n.data.type ?? n.data.role) !== "stellar"), [nodes]);
+  const treeSchema = useTreeStore((s) => s.treeSchema);
+  const stellars = useMemo(() => nodes.filter((n) => {
+    const render = treeSchema ? getNodeRender(treeSchema, (n.data.type ?? n.data.role) as string) : ((n.data.type ?? n.data.role) === "stellar" ? "star" : "planet");
+    return render === "star";
+  }), [nodes, treeSchema]);
+  const planets = useMemo(() => nodes.filter((n) => {
+    const render = treeSchema ? getNodeRender(treeSchema, (n.data.type ?? n.data.role) as string) : ((n.data.type ?? n.data.role) === "stellar" ? "star" : "planet");
+    return render !== "star";
+  }), [nodes, treeSchema]);
   const [mountedCount, setMountedCount] = useState(0);
 
   useEffect(() => {

--- a/src/components/canvas/TimelineView.tsx
+++ b/src/components/canvas/TimelineView.tsx
@@ -5,7 +5,7 @@ import { useTreeStore } from "@/lib/store/tree-store";
 import { NodeDetailPanel } from "@/components/panel/NodeDetailPanel";
 import type { Node3D } from "@/lib/store/tree-store";
 import type { ViewConfig } from "@/types/skill-tree";
-import { getNodeProperty } from "@/types/skill-tree";
+import { getNodeProperty, isCardType } from "@/types/skill-tree";
 import { sfxPanelOpen } from "@/lib/sfx";
 
 const STATUS_ICON: Record<string, string> = {
@@ -168,6 +168,7 @@ function LazyTicketCard({
 export function TimelineView({ viewConfig }: { viewConfig?: ViewConfig } = {}) {
   const dateField = viewConfig?.date_field;
   const nodes = useTreeStore((s) => s.nodes);
+  const treeSchema = useTreeStore((s) => s.treeSchema);
   const pinnedNodeId = useTreeStore((s) => s.pinnedNodeId);
   const setPinnedNode = useTreeStore((s) => s.setPinnedNode);
   const [filter, setFilter] = useState<"all" | "completed" | "pending">("all");
@@ -213,8 +214,8 @@ export function TimelineView({ viewConfig }: { viewConfig?: ViewConfig } = {}) {
 
   // Only planet/satellite nodes (tickets)
   const tickets = useMemo(() =>
-    nodes.filter((n) => (n.data.type ?? n.data.role) !== "stellar"),
-    [nodes]
+    nodes.filter((n) => isCardType(treeSchema ?? { properties: {} }, (n.data.type ?? n.data.role) as string)),
+    [nodes, treeSchema]
   );
 
   // Apply filter

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -1,5 +1,5 @@
 import type { SkillNode, SkillEdge, TreeSchema } from "@/types/skill-tree";
-import { DEFAULT_SCHEMA } from "@/types/skill-tree";
+import { DEFAULT_SCHEMA, resolveHierarchy } from "@/types/skill-tree";
 import { getChecklist } from "@/lib/content/checklist";
 
 export function buildSystemPrompt(
@@ -72,12 +72,16 @@ export function buildSystemPrompt(
     })
     .join("\n");
 
+  // Build hierarchy description
+  const hierarchy = resolveHierarchy(resolvedSchema);
+  const hierarchyDesc = hierarchy.levels
+    .map((l) => `- ${l.label.toUpperCase()} (role="${l.id}") — renders as ${l.render} in the 3D view`)
+    .join("\n");
+
   return `You are SkillForge AI, an expert learning coach that builds skill galaxies.
 
-The visualization is a 3D solar system galaxy:
-- STELLAR nodes are stars (suns) — one per major topic. They sit at the center of their system.
-- PLANET nodes orbit a stellar — these are key skills within that topic. Higher priority = bigger planet.
-- SATELLITE nodes orbit a planet — these are sub-skills, exercises, or details. Small moons.
+The visualization is a 3D solar system galaxy with the following hierarchy:
+${hierarchyDesc}
 
 Property schema for this tree:
 ${schemaDesc}
@@ -91,14 +95,14 @@ Explicit edges (depends_on / related / references):
 ${edgeView}
 
 RULES — Galaxy structure:
-1. When the user wants to learn a new topic, create ONE stellar + 3-8 planets + optional satellites using bulk_modify.
-2. Every planet MUST have a parent_id pointing to its stellar. Every satellite MUST point to its planet.
-3. Stellars have parent_id = null.
-4. Priority is a queue position (lower number = higher urgency, runs sooner): 1 = urgent/run next (large planet), 3 = normal, 5+ = backlog/nice-to-have (small planet). IMPORTANT: when the user asks to "prioritise" or "make this high priority", set priority to 1, NOT a high number like 99.
+1. When the user wants to create a new topic, create ONE ${hierarchy.levels[0]?.label ?? "top-level"} + 3-8 ${hierarchy.levels[1]?.label ?? "child"}s + optional ${hierarchy.levels[2]?.label ?? "sub-child"}s using bulk_modify.
+2. Every ${hierarchy.levels[1]?.label ?? "child"} MUST have a parent_id pointing to its ${hierarchy.levels[0]?.label ?? "parent"}. Every ${hierarchy.levels[2]?.label ?? "sub-child"} MUST point to its ${hierarchy.levels[1]?.label ?? "parent"}.
+3. ${hierarchy.levels[0]?.label ?? "Top-level"} nodes have parent_id = null.
+4. Priority is a queue position (lower number = higher urgency, runs sooner): 1 = urgent/run next, 3 = normal, 5+ = backlog. IMPORTANT: when the user asks to "prioritise" or "make this high priority", set priority to 1, NOT a high number like 99.
 5. Set status to the first option in the schema (e.g. "${resolvedSchema.properties.status?.options?.[0] ?? "locked"}") unless the user says otherwise.
-6. Use descriptive IDs: "web-dev" for stellar, "html-basics" for planet, "semantic-tags" for satellite.
-7. When adding to an existing stellar system, just add planets/satellites with the correct parent_id.
-8. Keep the galaxy balanced — don't put too many planets on one stellar (max ~8).
+6. Use descriptive IDs based on the content, e.g. "web-dev", "html-basics", "semantic-tags".
+7. When adding to an existing ${hierarchy.levels[0]?.label ?? "top-level"} system, just add children with the correct parent_id.
+8. Keep the galaxy balanced — don't put too many children on one parent (max ~8).
 
 RULES — Tool selection (IMPORTANT):
 - Use update_node ONLY for structural/display changes: label, description, role, parent_id. NEVER pass status or priority to update_node.

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -1,6 +1,6 @@
 import type { Tool } from "@anthropic-ai/sdk/resources/messages";
 import type { TreeSchema } from "@/types/skill-tree";
-import { DEFAULT_SCHEMA } from "@/types/skill-tree";
+import { DEFAULT_SCHEMA, resolveHierarchy } from "@/types/skill-tree";
 
 /** Build a description of valid properties from the tree schema for tool descriptions. */
 function describeProperties(schema: TreeSchema): string {
@@ -168,11 +168,17 @@ function buildStructureTools(schema: TreeSchema): Tool[] {
     ? { type: "string" as const, enum: statusOptions, description: "Initial status" }
     : { type: "string" as const, description: "Initial status" };
 
+  const hierarchy = resolveHierarchy(schema);
+  const levelIds = hierarchy.levels.map((l) => l.id);
+  const levelDesc = hierarchy.levels
+    .map((l) => `${l.id} = ${l.label} (renders as ${l.render})`)
+    .join(", ");
+
   return [
     {
       name: "add_node",
       description:
-        "Add a skill node to the galaxy. Stellar = main topic (sun at center of a system). Planet = important skill (orbits a stellar). Satellite = sub-skill or detail (orbits a planet).",
+        `Add a node to the galaxy. Hierarchy levels: ${levelDesc}. Top level sits at center, children orbit their parent.`,
       input_schema: {
         type: "object" as const,
         properties: {
@@ -181,8 +187,8 @@ function buildStructureTools(schema: TreeSchema): Tool[] {
           description: { type: "string", description: "1-2 sentence description" },
           role: {
             type: "string",
-            enum: ["stellar", "planet", "satellite"],
-            description: "stellar = main topic (star), planet = key skill (orbits a star), satellite = sub-skill (orbits a planet)",
+            enum: levelIds,
+            description: levelDesc,
           },
           parent_id: {
             type: "string",
@@ -219,7 +225,7 @@ function buildStructureTools(schema: TreeSchema): Tool[] {
           id: { type: "string", description: "ID of the node to update" },
           label: { type: "string", description: "New display name for the node" },
           description: { type: "string", description: "New 1-2 sentence description" },
-          role: { type: "string", enum: ["stellar", "planet", "satellite"], description: "New role" },
+          role: { type: "string", enum: levelIds, description: `New role: ${levelDesc}` },
           parent_id: { type: "string", description: "New parent node ID" },
         },
         required: ["id"],

--- a/src/lib/store/tree-store.ts
+++ b/src/lib/store/tree-store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import type { SkillNode, SkillEdge, EdgeType, NodeStatus, NodeRole, TreeSchema, ViewConfig } from "@/types/skill-tree";
-// NodeType is identical to NodeRole right now — imported for future use
+import { resolveHierarchy, getNodeRender } from "@/types/skill-tree";
 import type { NodeContent } from "@/types/node-content";
 import type { PendingChange } from "@/types/chat";
 import { createClient } from "@/lib/supabase/client";
@@ -110,14 +110,24 @@ function computeStellarPosition(index: number, total: number): [number, number, 
 }
 
 /** Resolve the effective role/type for layout — type column takes precedence over role. */
-function nodeType(n: SkillNode): NodeRole {
-  return (n.type ?? n.role) as NodeRole;
+function nodeType(n: SkillNode): string {
+  return (n.type ?? n.role) as string;
 }
 
-export function layoutGalaxy(nodes: SkillNode[]): Node3D[] {
-  const stellars = nodes.filter((n) => nodeType(n) === "stellar");
-  const planets = nodes.filter((n) => nodeType(n) === "planet");
-  const satellites = nodes.filter((n) => nodeType(n) === "satellite");
+/** Get the render tier for a node given the tree schema. */
+function nodeRender(n: SkillNode, schema?: TreeSchema): string {
+  if (schema) return getNodeRender(schema, nodeType(n));
+  // Legacy fallback
+  const t = nodeType(n);
+  if (t === "stellar") return "star";
+  if (t === "satellite") return "satellite";
+  return "planet";
+}
+
+export function layoutGalaxy(nodes: SkillNode[], schema?: TreeSchema): Node3D[] {
+  const stellars = nodes.filter((n) => nodeRender(n, schema) === "star");
+  const planets = nodes.filter((n) => nodeRender(n, schema) === "planet");
+  const satellites = nodes.filter((n) => nodeRender(n, schema) === "satellite");
 
   const result: Node3D[] = [];
   const positionMap = new Map<string, [number, number, number]>();
@@ -260,7 +270,7 @@ export const useTreeStore = create<TreeState>((set, get) => ({
     const baseData = existingIds.has(node.id)
       ? existing.map((n) => (n.id === node.id ? node : n.data))
       : [...existing.map((n) => n.data), node];
-    set({ nodes: layoutGalaxy(baseData) });
+    set({ nodes: layoutGalaxy(baseData, get().treeSchema ?? undefined) });
   },
 
   removeNode: (nodeId) => {
@@ -279,7 +289,7 @@ export const useTreeStore = create<TreeState>((set, get) => ({
     }
     const remaining = existing.filter((n) => !toRemove.has(n.id)).map((n) => n.data);
     set({
-      nodes: layoutGalaxy(remaining),
+      nodes: layoutGalaxy(remaining, get().treeSchema ?? undefined),
       selectedNodeId: toRemove.has(get().selectedNodeId ?? "") ? null : get().selectedNodeId,
     });
   },
@@ -290,7 +300,7 @@ export const useTreeStore = create<TreeState>((set, get) => ({
       n.id === nodeId ? { ...n.data, ...data } : n.data
     );
     if (data.type != null || data.role != null || data.parent_id != null || data.priority != null) {
-      set({ nodes: layoutGalaxy(allData) });
+      set({ nodes: layoutGalaxy(allData, get().treeSchema ?? undefined) });
     } else {
       set({
         nodes: existing.map((n) =>

--- a/src/types/skill-tree.ts
+++ b/src/types/skill-tree.ts
@@ -7,8 +7,26 @@ export interface PropertyDef {
   options?: string[]; // for select / multi_select
 }
 
+// ── Hierarchy types ─────────────────────────────────────────────────────────
+
+/** 3D rendering style — maps to solar system visual tier. */
+export type HierarchyRender = "star" | "planet" | "satellite";
+
+export interface HierarchyLevel {
+  id: string;          // stored in node's type/role column, e.g. "epic", "story", "task"
+  label: string;       // display name, e.g. "Epic", "Story", "Task"
+  render: HierarchyRender; // how to render in 3D view
+}
+
+export interface HierarchyConfig {
+  levels: HierarchyLevel[];
+  /** Depth index from which nodes appear as cards on the board (default 1 = skip top level). */
+  card_from: number;
+}
+
 export interface TreeSchema {
   properties: Record<string, PropertyDef>;
+  hierarchy?: HierarchyConfig;
 }
 
 // ── View config types ───────────────────────────────────────────────────────
@@ -28,6 +46,15 @@ export interface ViewConfig {
 
 // ── Default schema & views (mirrors legacy hardcoded behavior) ──────────────
 
+export const DEFAULT_HIERARCHY: HierarchyConfig = {
+  levels: [
+    { id: "stellar",   label: "Stellar",   render: "star" },
+    { id: "planet",    label: "Planet",     render: "planet" },
+    { id: "satellite", label: "Satellite",  render: "satellite" },
+  ],
+  card_from: 1,
+};
+
 export const DEFAULT_SCHEMA: TreeSchema = {
   properties: {
     status: { type: "select", options: ["locked", "queued", "in_progress", "completed"] },
@@ -35,6 +62,7 @@ export const DEFAULT_SCHEMA: TreeSchema = {
     due_date: { type: "date" },
     assignee: { type: "text" },
   },
+  hierarchy: DEFAULT_HIERARCHY,
 };
 
 export const DEFAULT_VIEW_CONFIGS: ViewConfig[] = [
@@ -133,7 +161,52 @@ export function resolveSchema(tree: SkillTree): TreeSchema {
   if (!schema || !schema.properties || Object.keys(schema.properties).length === 0) {
     return DEFAULT_SCHEMA;
   }
+  // Ensure hierarchy is present
+  if (!schema.hierarchy) {
+    return { ...schema, hierarchy: DEFAULT_HIERARCHY };
+  }
   return schema;
+}
+
+/** Resolve hierarchy config from schema, with defaults. */
+export function resolveHierarchy(schema: TreeSchema): HierarchyConfig {
+  return schema.hierarchy ?? DEFAULT_HIERARCHY;
+}
+
+/** Get the render style for a node type (e.g. "epic" → "star"). */
+export function getNodeRender(schema: TreeSchema, nodeType: string): HierarchyRender {
+  const hierarchy = resolveHierarchy(schema);
+  const level = hierarchy.levels.find((l) => l.id === nodeType);
+  if (level) return level.render;
+  // Legacy fallback
+  if (nodeType === "stellar") return "star";
+  if (nodeType === "satellite") return "satellite";
+  return "planet";
+}
+
+/** Get the hierarchy level IDs (e.g. ["epic", "story", "task"]). */
+export function getHierarchyIds(schema: TreeSchema): string[] {
+  return resolveHierarchy(schema).levels.map((l) => l.id);
+}
+
+/** Get the top-level type ID (depth 0 — rendered as star, hidden from board). */
+export function getTopLevelId(schema: TreeSchema): string {
+  return resolveHierarchy(schema).levels[0]?.id ?? "stellar";
+}
+
+/** Check if a node type should appear as a card on the board. */
+export function isCardType(schema: TreeSchema, nodeType: string): boolean {
+  const hierarchy = resolveHierarchy(schema);
+  const idx = hierarchy.levels.findIndex((l) => l.id === nodeType);
+  if (idx === -1) return true; // unknown type → show as card
+  return idx >= hierarchy.card_from;
+}
+
+/** Get the display label for a node type. */
+export function getTypeLabel(schema: TreeSchema, nodeType: string): string {
+  const hierarchy = resolveHierarchy(schema);
+  const level = hierarchy.levels.find((l) => l.id === nodeType);
+  return level?.label ?? nodeType;
 }
 
 /** Resolve view configs with defaults. */

--- a/supabase/migrations/010_hierarchy_config.sql
+++ b/supabase/migrations/010_hierarchy_config.sql
@@ -1,0 +1,16 @@
+-- Migration 010: Backfill hierarchy config into tree schemas
+-- Adds hierarchy configuration to existing trees that don't have one.
+-- Non-destructive: only updates trees where schema has no hierarchy key.
+
+UPDATE skill_trees
+SET schema = schema || '{
+  "hierarchy": {
+    "levels": [
+      { "id": "stellar",   "label": "Stellar",   "render": "star" },
+      { "id": "planet",    "label": "Planet",     "render": "planet" },
+      { "id": "satellite", "label": "Satellite",  "render": "satellite" }
+    ],
+    "card_from": 1
+  }
+}'::jsonb
+WHERE schema->>'hierarchy' IS NULL;


### PR DESCRIPTION
## Summary
Users can now define custom hierarchy levels per tree (e.g. Epic/Story/Task instead of Stellar/Planet/Satellite). The 3D solar system view maps custom types to star/planet/moon rendering.

## Schema structure
```json
{
  "hierarchy": {
    "levels": [
      { "id": "epic",    "label": "Epic",    "render": "star" },
      { "id": "story",   "label": "Story",   "render": "planet" },
      { "id": "subtask", "label": "Subtask", "render": "satellite" }
    ],
    "card_from": 1
  }
}
```

## Changes
- **Types**: `HierarchyConfig`, `HierarchyLevel` + helper functions
- **Migration 010**: backfills default hierarchy into existing trees
- **Layout engine**: `layoutGalaxy()` uses `getNodeRender()` for flexible type mapping
- **3D rendering**: `SkillNode3D` + `SkillTreeCanvas` use render tiers from schema
- **Kanban/Timeline**: use `isCardType()` instead of hardcoded stellar check
- **AI tools/prompt**: role enum and descriptions generated from hierarchy config

## Action required
Run migration 010 in Supabase SQL Editor.

## Test plan
- [ ] Existing trees render exactly as before (backward compat)
- [ ] Kanban board still filters out top-level nodes
- [ ] AI creates nodes with correct roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)