### PR TITLE
Add backlog status for PM-created tickets

### DIFF
--- a/src/components/panel/PanelStatus.tsx
+++ b/src/components/panel/PanelStatus.tsx
@@ -1,6 +1,7 @@
 import type { NodeStatus } from "@/types/skill-tree";
 
 const statusInfo: Partial<Record<NodeStatus, { label: string; bar: string }>> = {
+  backlog:     { label: "Backlog", bar: "w-0" },
   locked:      { label: "Not started", bar: "w-0" },
   queued:      { label: "Queued", bar: "w-1/4" },
   in_progress: { label: "In progress", bar: "w-1/2" },

--- a/src/lib/store/tree-store.ts
+++ b/src/lib/store/tree-store.ts
@@ -90,7 +90,7 @@ interface TreeState {
   redo: () => void;
 }
 
-const STATUS_CYCLE: NodeStatus[] = ["locked", "queued", "in_progress", "completed"];
+const STATUS_CYCLE: NodeStatus[] = ["backlog", "locked", "queued", "in_progress", "completed"];
 
 // --- Orbital Layout Engine ---
 

--- a/src/types/skill-tree.ts
+++ b/src/types/skill-tree.ts
@@ -57,7 +57,7 @@ export const DEFAULT_HIERARCHY: HierarchyConfig = {
 
 export const DEFAULT_SCHEMA: TreeSchema = {
   properties: {
-    status: { type: "select", options: ["locked", "queued", "in_progress", "completed"] },
+    status: { type: "select", options: ["backlog", "locked", "queued", "in_progress", "completed"] },
     priority: { type: "number" },
     due_date: { type: "date" },
     assignee: { type: "text" },
@@ -73,7 +73,7 @@ export const DEFAULT_VIEW_CONFIGS: ViewConfig[] = [
 
 // ── Legacy types (kept for backward compat during transition) ───────────────
 
-export type NodeStatus = "locked" | "queued" | "in_progress" | "completed";
+export type NodeStatus = "backlog" | "locked" | "queued" | "in_progress" | "completed";
 export type NodeRole = "stellar" | "planet" | "satellite";
 export type NodeType = NodeRole;
 

--- a/supabase/migrations/011_backlog_status.sql
+++ b/supabase/migrations/011_backlog_status.sql
@@ -1,0 +1,11 @@
+-- Migration 011: Add 'backlog' status to skill_nodes
+-- backlog = ticket created but not yet ready for agent pickup
+-- Flow: backlog → queued (user promotes) → in_progress (agent picks up) → completed
+
+-- Drop old check constraint and add new one including 'backlog'
+ALTER TABLE skill_nodes
+  DROP CONSTRAINT IF EXISTS skill_nodes_status_check;
+
+ALTER TABLE skill_nodes
+  ADD CONSTRAINT skill_nodes_status_check
+  CHECK (status IN ('backlog', 'locked', 'queued', 'in_progress', 'completed'));


### PR DESCRIPTION
## Summary
- Added `backlog` as a valid ticket status
- New DB migration (011): adds backlog to status constraint
- Kanban board shows backlog as a new column
- PanelStatus shows "Backlog" label with progress bar

## Ticket flow
```
backlog → locked → queued → in_progress → completed
  (PM)              (user)    (agent)       (agent)
```

- PM creates tickets with status `backlog`
- User promotes to `queued` when ready for agent
- Coding agent only picks from `queued`

## Files changed
- `supabase/migrations/011_backlog_status.sql` — DB constraint
- `src/types/skill-tree.ts` — type + default schema
- `src/lib/store/tree-store.ts` — status cycle
- `src/components/panel/PanelStatus.tsx` — display label

🤖 Generated with [Claude Code](https://claude.com/claude-code)