### PR TITLE
Replace locked status with backlog

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -15,7 +15,7 @@ interface ThumbnailNode {
   type: "stellar" | "planet" | "satellite";
   role: "stellar" | "planet" | "satellite";
   parent_id: string | null;
-  status: "locked" | "in_progress" | "completed";
+  status: "backlog" | "in_progress" | "completed";
 }
 
 interface TreeWithProgress extends SkillTree {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,7 +15,7 @@
   --scrollbar-thumb: rgba(0, 0, 0, 0.15);
   --scrollbar-thumb-hover: rgba(0, 0, 0, 0.25);
   --toast-bg: #ffffff;
-  --node-locked-bg: rgba(240, 244, 250, 0.75);
+  --node-backlog-bg: rgba(240, 244, 250, 0.75);
 }
 
 /* Dark mode */
@@ -29,7 +29,7 @@
   --scrollbar-thumb: rgba(255, 255, 255, 0.1);
   --scrollbar-thumb-hover: rgba(255, 255, 255, 0.2);
   --toast-bg: #0f172a;
-  --node-locked-bg: rgba(10, 14, 26, 0.75);
+  --node-backlog-bg: rgba(10, 14, 26, 0.75);
 }
 
 /* ── Base Styles ────────────────────────────────────────────── */
@@ -79,8 +79,8 @@ canvas {
   50%       { box-shadow: 0 0 12px 5px rgba(52, 211, 153, 0.65), 0 0 24px 8px rgba(52, 211, 153, 0.25); }
 }
 
-.node-status-locked {
-  background: var(--node-locked-bg) !important;
+.node-status-backlog {
+  background: var(--node-backlog-bg) !important;
   opacity: 0.55;
 }
 

--- a/src/components/canvas/GanttView.tsx
+++ b/src/components/canvas/GanttView.tsx
@@ -21,7 +21,7 @@ const STATUS_COLORS: Record<string, string> = {
   completed:   "#22d3ee",   // cyan   — ticket finished
   in_progress: "#f59e0b",   // amber  — actively being worked
   queued:      "#a78bfa",   // violet — waiting to start
-  locked:      "#475569",   // slate  — not yet reachable
+  backlog:     "#475569",   // slate  — not yet reachable
 };
 
 const TYPE_COLORS: Record<string, string> = {
@@ -409,7 +409,7 @@ export function GanttView() {
 
               // Duration fill: completed tickets show full solid bar (actual duration known).
               // In-progress: partial fill based on days elapsed vs bar width.
-              // Queued/locked: empty fill — ticket hasn't started.
+              // Queued/backlog: empty fill — ticket hasn't started.
               const barDurationDays = row.barWidth / PX_PER_DAY;
               const elapsedDays =
                 (Date.now() - new Date(row.startLabel).getTime()) /

--- a/src/components/canvas/KanbanView.tsx
+++ b/src/components/canvas/KanbanView.tsx
@@ -47,7 +47,7 @@ function buildColumnConfigs(schema: TreeSchema, groupBy: string): ColumnConfig[]
 
 // Map between column id (schema option value) and legacy NodeStatus
 const LEGACY_STATUS_MAP: Record<string, NodeStatus> = {
-  locked: "locked",
+  backlog: "backlog",
   queued: "queued",
   in_progress: "in_progress",
   completed: "completed",

--- a/src/components/canvas/SearchPanel.tsx
+++ b/src/components/canvas/SearchPanel.tsx
@@ -69,7 +69,7 @@ export function SearchPanel() {
   }
 
   const statusDot: Record<string, string> = {
-    locked: "bg-slate-600",
+    backlog: "bg-slate-600",
     in_progress: "bg-amber-500",
     completed: "bg-emerald-500",
   };

--- a/src/components/canvas/SkillNode3D.tsx
+++ b/src/components/canvas/SkillNode3D.tsx
@@ -10,7 +10,7 @@ import type { NodeStatus } from "@/types/skill-tree";
 import { getNodeRender } from "@/types/skill-tree";
 
 // ---------------------------------------------------------------------------
-// UnlockParticles — burst that plays once when a node goes locked→in_progress
+// UnlockParticles — burst that plays once when a node goes backlog→in_progress
 // ---------------------------------------------------------------------------
 
 const PARTICLE_COUNT = 48;
@@ -136,13 +136,13 @@ const STATUS_BRIGHTNESS: Record<
   NodeStatus,
   { opacity: number; emissive: number; atmosphere: number; cloudOpacity: number; ringOpacity: number; labelAlpha: number }
 > = {
-  locked:      { opacity: 0.3,  emissive: 0.0,  atmosphere: 0.02, cloudOpacity: 0.1,  ringOpacity: 0.1,  labelAlpha: 0.4 },
+  backlog:     { opacity: 0.3,  emissive: 0.0,  atmosphere: 0.02, cloudOpacity: 0.1,  ringOpacity: 0.1,  labelAlpha: 0.4 },
   queued:      { opacity: 0.55, emissive: 0.08, atmosphere: 0.06, cloudOpacity: 0.3,  ringOpacity: 0.3,  labelAlpha: 0.65 },
   in_progress: { opacity: 0.85, emissive: 0.25, atmosphere: 0.12, cloudOpacity: 0.5,  ringOpacity: 0.5,  labelAlpha: 0.85 },
   completed:   { opacity: 1.0,  emissive: 0.5,  atmosphere: 0.2,  cloudOpacity: 0.7,  ringOpacity: 0.7,  labelAlpha: 1.0 },
 };
 
-const STATUS_CYCLE: NodeStatus[] = ["locked", "in_progress", "completed"];
+const STATUS_CYCLE: NodeStatus[] = ["backlog", "in_progress", "completed"];
 
 function idSeed(id: string): number {
   let h = 0;
@@ -225,7 +225,7 @@ export const SkillNode3D = memo(function SkillNode3D({ node, parentMap, readOnly
     if (cloudsRef.current) cloudsRef.current.rotation.y = t * config.rotationSpeed * 1.3;
     if (atmosphereRef.current) atmosphereRef.current.scale.setScalar(hovered ? 1.25 : 1.15);
 
-    // Status glow: locked=none, in_progress=amber pulse, completed=green steady
+    // Status glow: backlog=none, in_progress=amber pulse, completed=green steady
     if (statusGlowRef.current) {
       const mat = statusGlowRef.current.material as THREE.MeshBasicMaterial;
       if (node.data.status === "completed") {
@@ -287,9 +287,9 @@ export const SkillNode3D = memo(function SkillNode3D({ node, parentMap, readOnly
     }
   });
 
-  // Detect locked → in_progress transition and fire particle burst
+  // Detect backlog → in_progress transition and fire particle burst
   useEffect(() => {
-    if (prevStatusRef.current === "locked" && node.data.status === "in_progress") {
+    if (prevStatusRef.current === "backlog" && node.data.status === "in_progress") {
       setUnlockBurst(true);
     }
     prevStatusRef.current = node.data.status;
@@ -327,7 +327,7 @@ export const SkillNode3D = memo(function SkillNode3D({ node, parentMap, readOnly
     document.body.style.cursor = "auto";
   }, [setHoveredNode]);
 
-  // Click → cycle status (locked → in_progress → completed) + persist to Supabase
+  // Click → cycle status (backlog → in_progress → completed) + persist to Supabase
   // In readOnly mode: only focus/pin, no status change
   const onClick = useCallback((e: any) => {
     e.stopPropagation();
@@ -428,7 +428,7 @@ export const SkillNode3D = memo(function SkillNode3D({ node, parentMap, readOnly
         </mesh>
       )}
 
-      {/* Status glow: locked=none, in_progress=amber pulse, completed=green steady */}
+      {/* Status glow: backlog=none, in_progress=amber pulse, completed=green steady */}
       <mesh ref={statusGlowRef} geometry={sharedGeo.atmosphere} scale={node.scale * 1.35} visible={false}>
         <meshBasicMaterial color="#00ff88" transparent opacity={0} side={THREE.BackSide} depthWrite={false} />
       </mesh>
@@ -480,7 +480,7 @@ export const SkillNode3D = memo(function SkillNode3D({ node, parentMap, readOnly
         </Text>
       </Billboard>
 
-      {/* Unlock particle burst — plays once on locked → in_progress */}
+      {/* Unlock particle burst — plays once on backlog → in_progress */}
       <UnlockParticles
         nodeScale={node.scale}
         playing={unlockBurst}

--- a/src/components/canvas/SkillTreeCanvas.tsx
+++ b/src/components/canvas/SkillTreeCanvas.tsx
@@ -215,7 +215,7 @@ const STATUS_COLORS: Record<string, string> = {
   completed:   "#22c55e",
   in_progress: "#f59e0b",
   queued:      "#6366f1",
-  locked:      "#1e293b",
+  backlog:     "#1e293b",
 };
 
 const BATCH_SIZE = 5;     // nodes per batch

--- a/src/components/canvas/SkillTreeView2D.tsx
+++ b/src/components/canvas/SkillTreeView2D.tsx
@@ -37,7 +37,7 @@ const VIRTUAL_ROOT_ID = "__ROOT__";
 interface PhaseStats {
   total: number;
   done: number;
-  status: "completed" | "in_progress" | "locked";
+  status: "completed" | "in_progress" | "backlog";
 }
 
 function computePhaseStats(
@@ -50,7 +50,7 @@ function computePhaseStats(
   const total = children.length;
   const done = children.filter((n) => n.data.status === "completed").length;
   const hasInProgress = children.some((n) => n.data.status === "in_progress");
-  let status: "completed" | "in_progress" | "locked" = "locked";
+  let status: "completed" | "in_progress" | "backlog" = "backlog";
   if (total > 0 && done === total) status = "completed";
   else if (done > 0 || hasInProgress) status = "in_progress";
   return { total, done, status };
@@ -123,7 +123,7 @@ function buildDagreLayout(
   visibleNodes.forEach((n, idx) => {
     const type = n.data.type ?? n.data.role;
     if (type === "stellar") {
-      const stats = phaseStats.get(n.id) ?? { total: 0, done: 0, status: "locked" as const };
+      const stats = phaseStats.get(n.id) ?? { total: 0, done: 0, status: "backlog" as const };
       const { w, h } = phaseNodeSize(stats.total);
       nodeSizeMap.set(n.id, { w, h });
       g.setNode(n.id, { width: w, height: h });
@@ -213,20 +213,20 @@ function pointsToPath(points: { x: number; y: number }[]): string {
 const STATUS_COLORS: Record<string, string> = {
   completed: "#34d399",  // green
   in_progress: "#f59e0b", // amber
-  locked: "#334155",      // dark slate
+  backlog: "#334155",      // dark slate
   queued: "#60a5fa",      // blue
 };
 
 const PHASE_GLOW: Record<string, string> = {
   completed: "0 0 18px 4px rgba(52,211,153,0.55)",
   in_progress: "0 0 16px 3px rgba(245,158,11,0.5)",
-  locked: "none",
+  backlog: "none",
 };
 
 const PHASE_BORDER: Record<string, string> = {
   completed: "#34d399",
   in_progress: "#f59e0b",
-  locked: "#334155",
+  backlog: "#334155",
 };
 
 export function SkillTreeView2D() {
@@ -405,7 +405,7 @@ export function SkillTreeView2D() {
               const total = children.length;
               const done = children.filter((n) => n.data.status === "completed").length;
               const hasInProgress = children.some((n) => n.data.status === "in_progress");
-              let st: "completed" | "in_progress" | "locked" = "locked";
+              let st: "completed" | "in_progress" | "backlog" = "backlog";
               if (total > 0 && done === total) st = "completed";
               else if (done > 0 || hasInProgress) st = "in_progress";
               return { total, done, status: st };
@@ -548,7 +548,7 @@ export function SkillTreeView2D() {
                   ? "rgba(99,102,241,0.28)"
                   : isPinned
                   ? "rgba(99,102,241,0.18)"
-                  : status === "locked"
+                  : status === "backlog"
                   ? "rgba(10,14,26,0.75)"
                   : "rgba(15,22,41,0.85)",
                 boxShadow: isHighlighted
@@ -566,7 +566,7 @@ export function SkillTreeView2D() {
                 padding: "6px 10px",
                 gap: 3,
                 transition: "border-color 0.15s, background 0.15s, box-shadow 0.15s",
-                opacity: status === "locked" ? 0.55 : 1,
+                opacity: status === "backlog" ? 0.55 : 1,
               }}
             >
               <div

--- a/src/components/canvas/TimelineView.tsx
+++ b/src/components/canvas/TimelineView.tsx
@@ -12,14 +12,14 @@ const STATUS_ICON: Record<string, string> = {
   completed:   "✅",
   in_progress: "⚡",
   queued:      "⏳",
-  locked:      "🔒",
+  backlog:     "📋",
 };
 
 const STATUS_COLOR: Record<string, string> = {
   completed:   "#22c55e",
   in_progress: "#f59e0b",
   queued:      "#6366f1",
-  locked:      "#475569",
+  backlog:     "#475569",
 };
 
 function formatDate(ts: string | undefined | null): string {
@@ -92,9 +92,9 @@ function LazyTicketCard({
 
   const isPinned = node.id === pinnedNodeId;
   const isFlashing = flashNodeIds.has(node.id);
-  const status = String(getNodeProperty(node.data, "status") ?? node.data.status ?? "locked");
+  const status = String(getNodeProperty(node.data, "status") ?? node.data.status ?? "backlog");
   const color = STATUS_COLOR[status] ?? "#475569";
-  const icon = STATUS_ICON[status] ?? "🔒";
+  const icon = STATUS_ICON[status] ?? "📋";
   const props = (node.data.properties ?? {}) as Record<string, unknown>;
   const itemId = props.item_id as string | undefined;
   const commitHash = props.commit_hash as string | undefined;

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -75,7 +75,7 @@ export function ChatPanel({ treeId, onCollapse }: ChatPanelProps) {
           tree_id: treeId,
           label: change.params.label as string,
           description: (change.params.description as string) ?? null,
-          status: (change.params.status as SkillNode["status"]) ?? "locked",
+          status: (change.params.status as SkillNode["status"]) ?? "backlog",
           type: ((change.params.type ?? change.params.role) as SkillNode["type"]) ?? "planet",
           role: ((change.params.type ?? change.params.role) as SkillNode["role"]) ?? "planet",
           parent_id: (change.params.parent_id as string) ?? null,

--- a/src/components/chat/PendingChange.tsx
+++ b/src/components/chat/PendingChange.tsx
@@ -36,7 +36,7 @@ export function PendingChange({ change, treeId }: PendingChangeProps) {
           tree_id: treeId,
           label: params.label as string,
           description: (params.description as string) ?? null,
-          status: (params.status as SkillNode["status"]) ?? "locked",
+          status: (params.status as SkillNode["status"]) ?? "backlog",
           type: resolvedType,
           role: resolvedType,
           parent_id: (params.parent_id as string) ?? null,

--- a/src/components/panel/NodeDetailPanel.tsx
+++ b/src/components/panel/NodeDetailPanel.tsx
@@ -18,7 +18,7 @@ import { PanelRelations } from "./PanelRelations";
 // ── Status config ─────────────────────────────────────────────────────────────
 
 const STATUS: Record<NodeStatus, { label: string; icon: string; border: string; glow: string; color: string; bar: string }> = {
-  locked:      { label: "LOCKED",      icon: "🔒", color: "#64748b", bar: "0%",   border: "rgba(100,116,139,0.5)", glow: "0 0 12px rgba(100,116,139,0.15)" },
+  backlog:     { label: "BACKLOG",     icon: "📋", color: "#64748b", bar: "0%",   border: "rgba(100,116,139,0.5)", glow: "0 0 12px rgba(100,116,139,0.15)" },
   queued:      { label: "QUEUED",      icon: "⏳", color: "#3b82f6", bar: "25%",  border: "rgba(59,130,246,0.7)",  glow: "0 0 20px rgba(59,130,246,0.35)"  },
   in_progress: { label: "ACTIVE",      icon: "⚡", color: "#f59e0b", bar: "50%",  border: "rgba(245,158,11,0.7)", glow: "0 0 20px rgba(245,158,11,0.35)"  },
   completed:   { label: "COMPLETED",   icon: "✅", color: "#22c55e", bar: "100%", border: "rgba(34,197,94,0.7)",  glow: "0 0 20px rgba(34,197,94,0.35)"   },
@@ -108,8 +108,8 @@ export function NodeDetailPanel({ node, pinned = false, onClose, readOnly = fals
   // Play open sound on mount
   useEffect(() => { sfxPanelOpen(); }, []);
 
-  const status = (node.data.status ?? "locked") as NodeStatus;
-  const cfg = STATUS[status] ?? STATUS.locked;
+  const status = (node.data.status ?? "backlog") as NodeStatus;
+  const cfg = STATUS[status] ?? STATUS.backlog;
   const props = (node.data.properties ?? {}) as Record<string, string | null>;
   const { pos, onDown, onMove, onUp } = useDraggable();
   const { size, onResizeDown, onResizeMove, onResizeUp } = useResizable();

--- a/src/components/panel/PanelStatus.tsx
+++ b/src/components/panel/PanelStatus.tsx
@@ -2,7 +2,7 @@ import type { NodeStatus } from "@/types/skill-tree";
 
 const statusInfo: Partial<Record<NodeStatus, { label: string; bar: string }>> = {
   backlog:     { label: "Backlog", bar: "w-0" },
-  locked:      { label: "Not started", bar: "w-0" },
+  backlog:     { label: "Backlog", bar: "w-0" },
   queued:      { label: "Queued", bar: "w-1/4" },
   in_progress: { label: "In progress", bar: "w-1/2" },
   completed:   { label: "Fully learned", bar: "w-full" },

--- a/src/components/ui/TreeThumbnail.tsx
+++ b/src/components/ui/TreeThumbnail.tsx
@@ -8,7 +8,7 @@ interface ThumbnailNode {
   type?: "stellar" | "planet" | "satellite";
   role: "stellar" | "planet" | "satellite";
   parent_id: string | null;
-  status: "locked" | "in_progress" | "completed";
+  status: "backlog" | "in_progress" | "completed";
 }
 
 interface TreeThumbnailProps {

--- a/src/lib/ai/prompt.ts
+++ b/src/lib/ai/prompt.ts
@@ -99,7 +99,7 @@ RULES — Galaxy structure:
 2. Every ${hierarchy.levels[1]?.label ?? "child"} MUST have a parent_id pointing to its ${hierarchy.levels[0]?.label ?? "parent"}. Every ${hierarchy.levels[2]?.label ?? "sub-child"} MUST point to its ${hierarchy.levels[1]?.label ?? "parent"}.
 3. ${hierarchy.levels[0]?.label ?? "Top-level"} nodes have parent_id = null.
 4. Priority is a queue position (lower number = higher urgency, runs sooner): 1 = urgent/run next, 3 = normal, 5+ = backlog. IMPORTANT: when the user asks to "prioritise" or "make this high priority", set priority to 1, NOT a high number like 99.
-5. Set status to the first option in the schema (e.g. "${resolvedSchema.properties.status?.options?.[0] ?? "locked"}") unless the user says otherwise.
+5. Set status to the first option in the schema (e.g. "${resolvedSchema.properties.status?.options?.[0] ?? "backlog"}") unless the user says otherwise.
 6. Use descriptive IDs based on the content, e.g. "web-dev", "html-basics", "semantic-tags".
 7. When adding to an existing ${hierarchy.levels[0]?.label ?? "top-level"} system, just add children with the correct parent_id.
 8. Keep the galaxy balanced — don't put too many children on one parent (max ~8).

--- a/src/lib/store/tree-store.ts
+++ b/src/lib/store/tree-store.ts
@@ -90,7 +90,7 @@ interface TreeState {
   redo: () => void;
 }
 
-const STATUS_CYCLE: NodeStatus[] = ["backlog", "locked", "queued", "in_progress", "completed"];
+const STATUS_CYCLE: NodeStatus[] = ["backlog", "queued", "in_progress", "completed"];
 
 // --- Orbital Layout Engine ---
 

--- a/src/types/skill-tree.ts
+++ b/src/types/skill-tree.ts
@@ -57,7 +57,7 @@ export const DEFAULT_HIERARCHY: HierarchyConfig = {
 
 export const DEFAULT_SCHEMA: TreeSchema = {
   properties: {
-    status: { type: "select", options: ["backlog", "locked", "queued", "in_progress", "completed"] },
+    status: { type: "select", options: ["backlog", "queued", "in_progress", "completed"] },
     priority: { type: "number" },
     due_date: { type: "date" },
     assignee: { type: "text" },
@@ -73,7 +73,7 @@ export const DEFAULT_VIEW_CONFIGS: ViewConfig[] = [
 
 // ── Legacy types (kept for backward compat during transition) ───────────────
 
-export type NodeStatus = "backlog" | "locked" | "queued" | "in_progress" | "completed";
+export type NodeStatus = "backlog" | "queued" | "in_progress" | "completed";
 export type NodeRole = "stellar" | "planet" | "satellite";
 export type NodeType = NodeRole;
 

--- a/supabase/migrations/011_backlog_status.sql
+++ b/supabase/migrations/011_backlog_status.sql
@@ -8,4 +8,4 @@ ALTER TABLE skill_nodes
 
 ALTER TABLE skill_nodes
   ADD CONSTRAINT skill_nodes_status_check
-  CHECK (status IN ('backlog', 'locked', 'queued', 'in_progress', 'completed'));
+  CHECK (status IN ('backlog', 'queued', 'in_progress', 'completed'));


### PR DESCRIPTION
## Summary
Removes `locked` status entirely, replaced by `backlog` everywhere.

**New ticket flow:**
```
backlog → queued → in_progress → completed
  (PM)     (user)    (agent)       (agent)
```

## Changes (18 files)
- Types, store, all canvas views, panel components, chat components, AI prompts, dashboard, CSS
- DB migration updated: constraint now `('backlog', 'queued', 'in_progress', 'completed')`

## Required: Run SQL migration
After merging, run in Supabase SQL Editor:
```sql
ALTER TABLE skill_nodes DROP CONSTRAINT IF EXISTS skill_nodes_status_check;
ALTER TABLE skill_nodes ADD CONSTRAINT skill_nodes_status_check 
  CHECK (status IN ('backlog', 'queued', 'in_progress', 'completed'));
UPDATE skill_nodes SET status = 'backlog' WHERE status = 'locked';
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)